### PR TITLE
This fix was needed since the birch migration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -37,7 +37,7 @@ import lms.envs.common
 from lms.envs.common import (
     USE_TZ, TECH_SUPPORT_EMAIL, PLATFORM_NAME, BUGS_EMAIL, DOC_STORE_CONFIG, ALL_LANGUAGES, WIKI_ENABLED, MODULESTORE,
     update_module_store_settings, ASSET_IGNORE_REGEX, COPYRIGHT_YEAR,
-    YOUTUBE_API_KEY,
+    DATA_DIR, YOUTUBE_API_KEY,
 )
 from path import path
 from warnings import simplefilter


### PR DESCRIPTION
Without the DATA_DIR all the imports in studio fail.
It was patched by ops in AWS as a fast hotfix