### PR TITLE
Supporting the front end of the org_course_creator role

### DIFF
--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -1,11 +1,12 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%! from opaque_keys.edx.keys import CourseKey %>
-<%! from student.roles import CourseRerunCreatorRole, OrgRerunCreatorRole %>
+<%! from student.roles import CourseRerunCreatorRole, OrgRerunCreatorRole, OrgCourseCreatorRole, UserBasedRole %>
 
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "home" %></%def>
 <%block name="title">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</%block>
 <%block name="bodyclass">is-signedin index view-dashboard</%block>
+
 
 <%block name="requirejs">
   require(["js/factories/index"], function (IndexFactory) {
@@ -18,12 +19,25 @@
   <header class="mast has-actions">
     <h1 class="page-header">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</h1>
 
+    <%
+      org_course_creator_status = 'notgranted'
+      org_course_creator_allowed_org = []
+
+      all_roles = UserBasedRole(request.user, 'course_creator').courses_with_role()
+      if all_roles:
+          org_course_creator_status = 'granted'
+          org_course_creator_allowed_org = [x.org for x in all_roles]
+      else:
+          org_course_creator_status = 'notgranted'
+          org_course_creator_allowed_org = []
+    %>
+
     % if user.is_active:
     <nav class="nav-actions" aria-label="${_('Page Actions')}">
       <h3 class="sr">${_("Page Actions")}</h3>
       <ul>
         <li class="nav-item">
-          % if course_creator_status=='granted':
+          % if course_creator_status=='granted' or org_course_creator_status=='granted':
           <a href="#" class="button new-button new-course-button"><i class="icon fa fa-plus icon-inline"></i>
               ${_("New Course")}</a>
           % elif course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
@@ -45,7 +59,7 @@
   <section class="content">
     <article class="content-primary" role="main">
 
-      % if course_creator_status=='granted':
+      % if course_creator_status=='granted' or org_course_creator_status=='granted':
       <div class="wrapper-create-element wrapper-create-course">
         <form class="form-create create-course course-info" id="create-course-form" name="create-course-form">
           <div class="wrap-error">
@@ -72,7 +86,15 @@
                   <label for="new-course-org">${_("Organization")}</label>
                   ## Translators: This is an example for the name of the organization sponsoring a course, seen when filling out the form to create a new course. The organization name cannot contain spaces.
                   ## Translators: "e.g. UniversityX or OrganizationX" is a placeholder displayed when user put no data into this field.
-                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
+                  %if org_course_creator_allowed_org:
+                  <select class="new-course-org" id="new-course-org" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
+                    %for org in org_course_creator_allowed_org:
+                    <option value="${ org }">${ org }</option>
+                    %endfor
+                  </select>
+                  %else:
+                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org"/>
+                  %endif
                   <span class="tip" id="tip-new-course-org">${_("The name of the organization sponsoring the course.")}  <strong>${_("Note: This is part of your course URL, so no spaces or special characters are allowed.")}</strong> ${_("This cannot be changed, but you can set a different display name in Advanced Settings later.")}</span>
                   <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
                 </li>
@@ -314,7 +336,7 @@
           </div>
         </div>
 
-        %if course_creator_status == "granted":
+        %if course_creator_status == "granted" or org_course_creator_status=='granted':
         <div class="notice-item has-actions">
           <div class="msg">
             <h3 class="title">${_('Create Your First Course')}</h3>

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -275,7 +275,7 @@ class OrgRerunCreatorRole(OrgRole):
 
 @register_access_role
 class OrgCourseCreatorRole(OrgRole):
-    """An ORG staff with ability to rerun all courses"""
+    """An ORG staff with ability to create new courses"""
     ROLE = 'org_course_creator_group'
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR modifies the index page of studio so that author can create courses inside the available organizations to them.

- If a user has org specific permissions, the input field is a select instead of a text input