### PR TITLE
Patch to the function that handles the static urls

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -6,6 +6,8 @@ from django.utils.translation import get_language_bidi
 
 <%def name='url(file, raw=False)'><%
 try:
+    if file.startswith("http"):
+        return file
     url = staticfiles_storage.url(file)
 except:
     url = file

--- a/lms/djangoapps/branding/__init__.py
+++ b/lms/djangoapps/branding/__init__.py
@@ -66,6 +66,8 @@ def get_logo_url():
     # let's use that
     image_url = microsite.get_value('logo_image_url')
     if image_url:
+        if image_url.startswith("http"):
+            return image_url
         return '{static_url}{image_url}'.format(
             static_url=settings.STATIC_URL,
             image_url=image_url


### PR DESCRIPTION
This patch uses startswith('http') . It would fail it the ressource being called would be something like http-image.jpg.
If that happens the browser will try to load a relative path that will fail with a 404 error.