### PR TITLE
Fix bug in our ma_lang_user_preference,

### DIFF
--- a/common/djangoapps/microsite_aware_functions/user_preference.py
+++ b/common/djangoapps/microsite_aware_functions/user_preference.py
@@ -3,15 +3,16 @@ Microsite aware user preferences
 """
 
 from lang_pref.api import released_languages
-from openedx.conf import settings
 
 
 def ma_lang_user_preference(user_pref):
     """
         Get a language user preference that is contained in the released LANGUAGES
-        or return the default language as the user preference
+        or return NONE with which we expect a later instance to decide the language
     """
     released_languages_list = released_languages()
-    if user_pref not in released_languages_list:
-        user_pref = settings.LANGUAGE_CODE
+    released_languages_code_list = {langObj.code for langObj in released_languages_list}
+
+    if user_pref not in released_languages_code_list:
+        user_pref = None
     return user_pref


### PR DESCRIPTION
Take in account released_languases is a list of objects
Return none instead of settings.Language_code, so that a later middleware decides the language.