### PR TITLE
Laq/unicode username

### DIFF
--- a/common/djangoapps/student/edraak_validation.py
+++ b/common/djangoapps/student/edraak_validation.py
@@ -1,36 +1,10 @@
 """
 Allow Unicode in Admin and LMS.
 """
-from django.contrib.auth.admin import UserAdmin
-from django import forms
-from ratelimitbackend import admin
 import re
-from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from django.core.validators import RegexValidator
 from django.utils.translation import ugettext_lazy as _
 unicode_username_re = re.compile(ur'^[\w.@_+-]+$', re.UNICODE)
-unicode_username_field = forms.RegexField(label=_("Username"),
-                                          max_length=30,
-                                          regex=unicode_username_re,
-                                          help_text=_("Required. 30 characters or fewer. Letters, digits and "
-                                                        "@/./+/-/_ only."),
-                                          error_messages={
-                                                'invalid': _("This value may contain only letters, numbers and"
-                                                            " @/./+/-/_ characters.")
-                                            })
-
-
-class UnicodeUserCreationForm(UserCreationForm):
-    username = unicode_username_field
-
-
-class UnicodeUserChangeForm(UserChangeForm):
-    username = unicode_username_field
-
-
-class UnicodeUserAdmin(UserAdmin):
-    form = UnicodeUserChangeForm
-    add_form = UnicodeUserCreationForm
 
 validate_username = RegexValidator(
     unicode_username_re,

--- a/common/djangoapps/student/edraak_validation.py
+++ b/common/djangoapps/student/edraak_validation.py
@@ -1,0 +1,39 @@
+"""
+Allow Unicode in Admin and LMS.
+"""
+from django.contrib.auth.admin import UserAdmin
+from django import forms
+from ratelimitbackend import admin
+import re
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django.core.validators import RegexValidator
+from django.utils.translation import ugettext_lazy as _
+unicode_username_re = re.compile(ur'^[\w.@_+-]+$', re.UNICODE)
+unicode_username_field = forms.RegexField(label=_("Username"),
+                                          max_length=30,
+                                          regex=unicode_username_re,
+                                          help_text=_("Required. 30 characters or fewer. Letters, digits and "
+                                                        "@/./+/-/_ only."),
+                                          error_messages={
+                                                'invalid': _("This value may contain only letters, numbers and"
+                                                            " @/./+/-/_ characters.")
+                                            })
+
+
+class UnicodeUserCreationForm(UserCreationForm):
+    username = unicode_username_field
+
+
+class UnicodeUserChangeForm(UserChangeForm):
+    username = unicode_username_field
+
+
+class UnicodeUserAdmin(UserAdmin):
+    form = UnicodeUserChangeForm
+    add_form = UnicodeUserCreationForm
+
+validate_username = RegexValidator(
+    unicode_username_re,
+    _("Enter a valid 'username' consisting of letters, numbers, spaces, underscores or hyphens."),
+    'invalid'
+)

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -107,7 +107,7 @@ class AccountCreationForm(forms.Form):
     validation, not rendering.
     """
     # TODO: Resolve repetition
-    username = forms.SlugField(
+    username = forms.CharField(
         min_length=2,
         max_length=30,
         error_messages={

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -114,7 +114,7 @@ class AccountCreationForm(forms.Form):
         error_messages={
             "required": _USERNAME_TOO_SHORT_MSG,
             "min_length": _USERNAME_TOO_SHORT_MSG,
-            "invalid": "Enter a valid 'username' consisting of letters, numbers, underscores or hyphens.",
+            "invalid": "Enter a valid 'username' consisting of letters, numbers, underscores or hyphens(No Spaces).",
             "max_length": _("Username cannot be more than %(limit_value)s characters long"),
         },
         validators=[validate_username],  # Allow Unicode usernames

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -114,6 +114,7 @@ class AccountCreationForm(forms.Form):
         error_messages={
             "required": _USERNAME_TOO_SHORT_MSG,
             "min_length": _USERNAME_TOO_SHORT_MSG,
+            "invalid": "Enter a valid 'username' consisting of letters, numbers, underscores or hyphens.",
             "max_length": _("Username cannot be more than %(limit_value)s characters long"),
         },
         validators=[validate_username],  # Allow Unicode usernames

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -22,6 +22,7 @@ from util.password_policy_validators import (
     validate_password_complexity,
     validate_password_dictionary,
 )
+from student.edraak_validation import validate_username
 
 
 class PasswordResetFormNoActive(PasswordResetForm):
@@ -112,10 +113,10 @@ class AccountCreationForm(forms.Form):
         max_length=30,
         error_messages={
             "required": _USERNAME_TOO_SHORT_MSG,
-            "invalid": _("Username should only consist of A-Z and 0-9, with no spaces."),
             "min_length": _USERNAME_TOO_SHORT_MSG,
             "max_length": _("Username cannot be more than %(limit_value)s characters long"),
-        }
+        },
+        validators=[validate_username],  # Allow Unicode usernames
     )
     email = forms.EmailField(
         max_length=75,  # Limit per RFCs is 254, but User's email field in django 1.4 only takes 75


### PR DESCRIPTION
This pull request allows using unicode characters in the username, it is inspired in the commits of edraak for given functionality: 

https://github.com/Edraak/edx-platform/commit/6ab243b64aab0ec53e0bb36f8a0224eae37a35da
https://github.com/Edraak/edx-platform/commit/8e5ca8c097a3fd2fc92ed4b7de0182dcf510e611

This is a simple version with this pitfalls:

* It does not allow spaces: edraak allows them, but in my tests they produce an error with the resolve. We could try to solve it and allow spaces(but i think that's a separate change) or as it was before restrict the spaces.

* Edraak commits also change the admin interface so that it allows changing the unicode usernames through the admin. With this pull request the unicode usernames show fine in the admin, but when changing them it only allows ascii. @felipemontoya  should we include those changes too?

* Edraak also seems to have moved the regex expression to the env file, this could maybe allow the regex to be microsite aware, what do you think?

* Finally: the file edraak_validator could be named edunext_validator, what do you think?
