### PR TITLE
Microsite available page

### DIFF
--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -56,6 +56,7 @@ class DatabaseMicrositeBackend(SettingsFileMicrositeBackend):
         except Microsite.DoesNotExist:
             if settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN']:
                 context = {
+                    'domain': domain,
                 }
                 return HttpResponseNotFound(edxmako.shortcuts.render_to_string('microsites/not_found.html', context))
 

--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -8,6 +8,7 @@ import edxmako
 import json
 
 from django.conf import settings
+from django.http import HttpResponseNotFound
 from microsite_configuration.backends.filebased import SettingsFileMicrositeBackend
 from microsite_configuration.models import Microsite
 
@@ -53,7 +54,10 @@ class DatabaseMicrositeBackend(SettingsFileMicrositeBackend):
             self._set_microsite_config_from_obj(subdomain, domain, values)
             return
         except Microsite.DoesNotExist:
-            return
+            if settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN']:
+                context = {
+                }
+                return HttpResponseNotFound(edxmako.shortcuts.render_to_string('microsites/not_found.html', context))
 
     def get_template_path(self, relative_path, **kwargs):
         """

--- a/common/djangoapps/microsite_configuration/microsite.py
+++ b/common/djangoapps/microsite_configuration/microsite.py
@@ -89,7 +89,7 @@ def set_by_domain(domain):
     For a given request domain, find a match in our microsite configuration
     and make it available to the complete django request process
     """
-    BACKEND.set_config_by_domain(domain)
+    return BACKEND.set_config_by_domain(domain)
 
 
 def enable_microsites(log):

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -30,9 +30,7 @@ class MicrositeMiddleware(object):
 
         domain = request.META.get('HTTP_HOST', None)
 
-        microsite.set_by_domain(domain)
-
-        return None
+        return microsite.set_by_domain(domain)
 
     def process_response(self, request, response):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -293,6 +293,7 @@ FEATURES = {
 
     # Turn on/off Microsites feature
     'USE_MICROSITES': False,
+    'USE_MICROSITE_AVAILABLE_SCREEN': True,
 
     # Turn on third-party auth. Disabled for now because full implementations are not yet available. Remember to syncdb
     # if you enable this; we don't create tables by default.


### PR DESCRIPTION
When a user lands on a page that is not configured to be a microsite, a new page appears that directs them to the marketing page or in general tells them the domain is not properly configured.

This prevents confusions raised currently by the default microsite.