### PR TITLE
Supporting redirect of static pages

### DIFF
--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import redirect
 from django.conf import settings
 from django.http import HttpResponseNotFound, HttpResponseServerError, Http404
 from django.views.decorators.csrf import ensure_csrf_cookie
+from microsite_configuration import microsite
 
 from util.cache import cache_if_anonymous
 
@@ -39,6 +40,10 @@ def render(request, template):
 
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
+    mktg_redirects = microsite.get_value('MKTG_REDIRECTS', {})
+    if template in mktg_redirects:
+        return redirect(mktg_redirects.get(template, '/'))
+
     return render_to_response('static_templates/' + template, {})
 
 


### PR DESCRIPTION
Using a dict to store redirects that can be returned instead of rendering a static template when handling keys in MKTG_URL_LINK_MAP