### PR TITLE
adding microsite awareness email backend to identify distinct sender …

### DIFF
--- a/common/djangoapps/edunext/smtpbackend.py
+++ b/common/djangoapps/edunext/smtpbackend.py
@@ -1,0 +1,20 @@
+"""
+Microsite configuration email backend module.
+
+Contains the class for microsite email backend.
+
+"""
+
+from django.core.mail.backends.smtp import EmailBackend
+from openedx.conf import settings
+
+class MicrositeEmailBackend (EmailBackend):
+
+    def __init__(self, host=None, port=None, username=None, password=None,
+                 use_tls=None, fail_silently=False, use_ssl=None, timeout=None,
+                 ssl_keyfile=None, ssl_certfile=None,
+                 **kwargs):
+        
+        super(MicrositeEmailBackend, self).__init__()
+        self.username = settings.EMAIL_HOST_USER
+        self.password = settings.EMAIL_HOST_PASSWORD

--- a/common/djangoapps/edunext/smtpbackend.py
+++ b/common/djangoapps/edunext/smtpbackend.py
@@ -17,6 +17,6 @@ class MicrositeAwareEmailBackend (EmailBackend):
                  ssl_keyfile=None, ssl_certfile=None,
                  **kwargs):
 
-        super(MicrositeEmailBackend, self).__init__()
+        super(MicrositeAwareEmailBackend, self).__init__()
         self.username = settings.EMAIL_HOST_USER
         self.password = settings.EMAIL_HOST_PASSWORD

--- a/common/djangoapps/edunext/smtpbackend.py
+++ b/common/djangoapps/edunext/smtpbackend.py
@@ -3,18 +3,20 @@ Microsite configuration email backend module.
 
 Contains the class for microsite email backend.
 
+
 """
 
 from django.core.mail.backends.smtp import EmailBackend
 from openedx.conf import settings
 
-class MicrositeEmailBackend (EmailBackend):
+
+class MicrositeAwareEmailBackend (EmailBackend):
 
     def __init__(self, host=None, port=None, username=None, password=None,
                  use_tls=None, fail_silently=False, use_ssl=None, timeout=None,
                  ssl_keyfile=None, ssl_certfile=None,
                  **kwargs):
-        
+
         super(MicrositeEmailBackend, self).__init__()
         self.username = settings.EMAIL_HOST_USER
         self.password = settings.EMAIL_HOST_PASSWORD


### PR DESCRIPTION
…domains. Now emails are delivered through mailgun.

These are requiered configuration tokens
env tokens
EMAIL_BACKEND = 'edunext.smtpbackend.MicrositeEmailBackend'
EMAIL_HOST = 'smtp.mailgun.org'
EMAIL_PORT = 587
