### PR TITLE
Forcing the right path for templates at the template loader

### DIFF
--- a/common/djangoapps/edxmako/makoloader.py
+++ b/common/djangoapps/edxmako/makoloader.py
@@ -10,6 +10,7 @@ from django.template import Engine
 from edxmako.template import Template
 
 from openedx.core.lib.tempdir import mkdtemp_clean
+from microsite_configuration import microsite
 
 log = logging.getLogger(__name__)
 
@@ -67,6 +68,7 @@ class MakoLoader(object):
 
     def load_template_source(self, template_name, template_dirs=None):
         # Just having this makes the template load as an instance, instead of a class.
+        template_name = microsite.get_template_path(template_name)
         return self.base_loader.load_template_source(template_name, template_dirs)
 
     def reset(self):

--- a/common/djangoapps/microsite_configuration/backends/filebased.py
+++ b/common/djangoapps/microsite_configuration/backends/filebased.py
@@ -57,7 +57,7 @@ class EdunextCompatibleFilebasedMicrositeTemplateBackend(FilebasedMicrositeTempl
                 template_dir,
                 'templates',
                 relative_path
-                )
+            )
 
             if os.path.isfile(search_path):
                 path = '{0}/templates/{1}'.format(

--- a/common/djangoapps/microsite_configuration/templatetags/microsite.py
+++ b/common/djangoapps/microsite_configuration/templatetags/microsite.py
@@ -89,3 +89,11 @@ def microsite_template_path(template_name):
     Django template filter to apply template overriding to microsites
     """
     return microsite.get_template_path(template_name)
+
+
+@register.filter
+def microsite_get_value(value, default=None):
+    """
+    Django template filter that wrapps the microsite.get_value function
+    """
+    return microsite.get_value(value, default)


### PR DESCRIPTION
Using the microsite.get_template_path on every page load.