### PR TITLE
Changing the permission, to something that can be activated in studio

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -165,7 +165,8 @@ def instructor_dashboard_2(request, course_id):
     # This is used to generate example certificates
     # and enable self-generated certificates for a course.
     certs_enabled = CertificateGenerationConfiguration.current().enabled
-    if certs_enabled and access['admin']:
+    # eduNEXT changed on 14.07.2016 to allow access to the course-administrators (as per studio)
+    if certs_enabled and access['instructor']:
         sections.append(_section_certificates(course))
 
     disable_buttons = not _is_small_course(course_key)


### PR DESCRIPTION
This PR changes the required permissions to access the certificates panel in studio, to the administrator of a course. The administrator (actually `instructor) , can be changed in studio and it is the same permission that we currently use for certificate activation