### PR TITLE
Adding the xblock_i18n tag to studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -920,6 +920,9 @@ INSTALLED_APPS = (
     # Tagging
     'cms.lib.xblock.tagging',
 
+    # eduNEXT special modules
+    'edunext',
+
     # Enables default site and redirects
     'django_sites_extensions',
 )


### PR DESCRIPTION
Adding the edunext app, so the template tags are available for the django_template renderer.

Solves EDNX-254

@jfavellar90 