### PR TITLE
Implementing a cache for the result of the function. 

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -331,6 +331,7 @@ MIDDLEWARE_CLASSES = (
     'crum.CurrentRequestUserMiddleware',
     'request_cache.middleware.RequestCache',
     'header_control.middleware.HeaderControlMiddleware',
+    'microsite_configuration.middleware.SimpleMicrositeMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/common/djangoapps/microsite_configuration/backends/base.py
+++ b/common/djangoapps/microsite_configuration/backends/base.py
@@ -140,8 +140,10 @@ class BaseMicrositeBackend(AbstractBaseMicrositeBackend):
         """
         Stores a key value pair in a cache scoped to the thread
         """
-        if hasattr(self.current_request_configuration, 'cache'):
-            self.current_request_configuration.cache[key] = value
+        if not hasattr(self.current_request_configuration, 'cache'):
+            self.current_request_configuration.cache = {}
+
+        self.current_request_configuration.cache[key] = value
 
     def set_config_by_domain(self, domain):
         """

--- a/common/djangoapps/microsite_configuration/backends/database.py
+++ b/common/djangoapps/microsite_configuration/backends/database.py
@@ -254,6 +254,11 @@ class EdunextCompatibleDatabaseMicrositeBackend(DatabaseMicrositeBackend):
         if not self.has_configuration_set():
             return default
 
+        cache_key = "org-value-{}-{}".format(org, val_name)
+        cached_value = self.get_key_from_cache(cache_key)
+        if cached_value:
+            return cached_value
+
         # Filter at the db
         candidates = Microsite.objects.all()
         for microsite in candidates:
@@ -263,8 +268,11 @@ class EdunextCompatibleDatabaseMicrositeBackend(DatabaseMicrositeBackend):
                 if isinstance(org_filter, basestring):
                     org_filter = set([org_filter])
                 if org in org_filter:
-                    return current.get(val_name, default)
+                    result = current.get(val_name, default)
+                    self.set_key_to_cache(cache_key, result)
+                    return result
 
+        self.set_key_to_cache(cache_key, default)
         return default
 
     def get_all_orgs(self):

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -15,7 +15,20 @@ from opaque_keys.edx.keys import CourseKey
 from microsite_configuration import microsite
 
 
-class MicrositeMiddleware(object):
+class SimpleMicrositeMiddleware(object):
+    """
+    Middleware class which will clear any data from the microsite module on exit
+    """
+
+    def process_response(self, request, response):
+        """
+        Middleware exit point to delete cache data.
+        """
+        microsite.clear()
+        return response
+
+
+class MicrositeMiddleware(SimpleMicrositeMiddleware):
     """
     Middleware class which will bind configuration information regarding 'microsites' on a per request basis.
     The actual configuration information is taken from Django settings information
@@ -33,13 +46,6 @@ class MicrositeMiddleware(object):
         microsite.set_by_domain(domain)
 
         return None
-
-    def process_response(self, request, response):
-        """
-        Middleware entry point for request completion.
-        """
-        microsite.clear()
-        return response
 
 
 class MicrositeSessionCookieDomainMiddleware(object):

--- a/common/djangoapps/microsite_configuration/middleware.py
+++ b/common/djangoapps/microsite_configuration/middleware.py
@@ -20,6 +20,7 @@ class SimpleMicrositeMiddleware(object):
     Middleware class which will clear any data from the microsite module on exit
     """
 
+    # pylint: disable=unused-argument
     def process_response(self, request, response):
         """
         Middleware exit point to delete cache data.


### PR DESCRIPTION
This PR makes it so that in studio, the calls to the microsite.get_value_for_org method use a local cache to improve the performance of loading the /home/ or /assets/COURSE_ID/ pages

The cache lives on the threading.local data so, we need to clear it after each request.

Reviewers
- [x] @jfavellar90 
- [x] @diegomillan 