### PR TITLE
Fixing the circle tests

### DIFF
--- a/lms/templates/google_analytics.html
+++ b/lms/templates/google_analytics.html
@@ -2,6 +2,8 @@
 <%!
 from microsite_configuration import microsite
 %>
+<% ga_acct = microsite.is_request_in_microsite() %>
+% if ga_acct:
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -19,3 +21,4 @@ from microsite_configuration import microsite
 % endif
 
 </script>
+% endif


### PR DESCRIPTION
This PR uses a flag to output the ga_script. This fixes the third_party_auth test.

@jfavellar90 @Bound3R 

I went with the is_request_in_microsite() method, but we could check for other setting. For example settings.DEBUG, but I was not sure about that. What do yo guys think?