### PR TITLE
Change in 404 template needed by the smoke tests

### DIFF
--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -18,3 +18,5 @@ from openedx.core.djangolib.markup import HTML, Text
       )}</p>
     </section>
 </main>
+## This line is necessary for the smoke tests. Do not remove
+<input type="hidden" id="not-found-hidden-error" name="not-found" value="404">


### PR DESCRIPTION
In this PR I'm adding a hidden input which is read by the smoke tests to identify a page with 404

@felipemontoya 
@Bound3R 

@Bound3R do you agree with this?