### PR TITLE
Making the url settings object use the proxy for microsite_configuration

### DIFF
--- a/lms/djangoapps/course_wiki/tab.py
+++ b/lms/djangoapps/course_wiki/tab.py
@@ -3,7 +3,7 @@ These callables are used by django-wiki to check various permissions
 a user has on an article.
 """
 
-from django.conf import settings
+from openedx.conf import settings
 from django.utils.translation import ugettext_noop
 
 from courseware.tabs import EnrolledTab

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -2,7 +2,7 @@
 URLs for LMS
 """
 
-from django.conf import settings
+from openedx.conf import settings
 from django.conf.urls import patterns, include, url
 from django.views.generic.base import RedirectView
 from ratelimitbackend import admin


### PR DESCRIPTION
This PR makes the urls module of the lms susceptible to changes at the site object.

Merging this will allow us to change the wiki settings on a a per-site basis. This way we can turn it off completely and only activate every site upon request. As a side effect many other urls would also be controllable now.

Reviewers:
@jfavellar90 

FYI:
@juancamilom 
