### PR TITLE
Bumping version of email extensions

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -8,6 +8,6 @@
 -r custom.txt
 
 # For HTML email:
-git+https://github.com/eduNEXT/openedx-email-extensions.git@a91563cad0970fbc0d77c6dacdb7aa3a045404e7#egg=openedx-email-extensions==0.1.2
+git+https://github.com/eduNEXT/openedx-email-extensions.git@8cfed23637afcbb1cd5887abf414363f31dce7f2#egg=openedx-email-extensions==0.1.3
 # For general Edunext extensions
 git+https://github.com/eduNEXT/edunext-openedx-extensions@4e364a67d15d2eaefc87943c267581ab8e94c80a#egg=edunext-openedx-extensions==0.3.5


### PR DESCRIPTION
This PR bumps the version of email extensions. Related with [this PR](https://github.com/eduNEXT/openedx-email-extensions/pull/14)

@juancamilom 
@felipemontoya 