### PR TITLE
add extra conditional for mktg links when have empty values

### DIFF
--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -43,7 +43,7 @@ def render(request, template):
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
     mktg_redirects = microsite.get_value('MKTG_REDIRECTS', {})
-    if template in mktg_redirects and mktg_redirects.get(template) :
+    if template in mktg_redirects and mktg_redirects.get(template):
         return redirect(mktg_redirects.get(template, '/'))
 
     # Guess content type from file extension

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -43,7 +43,7 @@ def render(request, template):
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
     mktg_redirects = microsite.get_value('MKTG_REDIRECTS', {})
-    if template in mktg_redirects:
+    if template in mktg_redirects and mktg_redirects.get(template) :
         return redirect(mktg_redirects.get(template, '/'))
 
     # Guess content type from file extension


### PR DESCRIPTION
several problems were encountered configuring these redirects when there were empty values.

eg:
"MKTG_REDIRECTS":{
    "about.html":"https://www.edunext.co/about-edunext",
    "contact.html":"https://www.edunext.co#home-contact",
    "faq.html":"https://www.edunext.co/tos",
    "honor.html":"",
    "privacy":"",
    "tos.html":"https://www.edunext.co/tos"
  },