### PR TITLE
add specific version of nodeJs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   python:
     version: 2.7.10
+  node:
+    version: 5.12.0
 
 general:
   artifacts:


### PR DESCRIPTION
simply add the nodeJS version as a requirement in the circle ci configuration so that the npm packages were not deprecated.