### PR TITLE
gi/ednx/BC-14 Support for custom permissions on course rerun handlers

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -65,7 +65,16 @@ from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.core.lib.courses import course_image_url
 from student import auth
 from student.auth import has_course_author_access, has_studio_read_access, has_studio_write_access
-from student.roles import CourseCreatorRole, CourseInstructorRole, CourseStaffRole, GlobalStaff, UserBasedRole
+from student.roles import (
+    CourseInstructorRole,
+    CourseStaffRole,
+    CourseCreatorRole,
+    GlobalStaff,
+    UserBasedRole,
+    CourseRerunCreatorRole,
+    OrgRerunCreatorRole,
+    OrgCourseCreatorRole
+)
 from util.course import get_link_for_about_page
 from util.date_utils import get_default_time_display
 from util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
@@ -279,10 +288,12 @@ def course_rerun_handler(request, course_key_string):
     GET
         html: return html page with form to rerun a course for the given course id
     """
-    # Only global staff (PMs) are able to rerun courses during the soft launch
-    if not GlobalStaff().has_user(request.user):
-        raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
+    rerun_permission = CourseRerunCreatorRole(
+        course_key).has_user(request.user) or OrgRerunCreatorRole(course_key.org).has_user(request.user)
+
+    if not GlobalStaff().has_user(request.user) and not rerun_permission:
+        raise PermissionDenied()
     with modulestore().bulk_operations(course_key):
         course_module = get_course_and_check_access(course_key, request.user, depth=3)
         if request.method == 'GET':
@@ -731,11 +742,14 @@ def _create_or_rerun_course(request):
     Returns the destination course_key and overriding fields for the new course.
     Raises DuplicateCourseError and InvalidKeyError
     """
-    if not auth.user_has_role(request.user, CourseCreatorRole()):
-        raise PermissionDenied()
-
     try:
         org = request.json.get('org')
+        rerun_permission = OrgRerunCreatorRole(org).has_user(
+            request.user) or OrgCourseCreatorRole(org).has_user(request.user)
+
+        if not auth.user_has_role(request.user, CourseCreatorRole()) and not rerun_permission:
+            raise PermissionDenied()
+
         course = request.json.get('number', request.json.get('course'))
         display_name = request.json.get('display_name')
         # force the start date for reruns and allow us to override start via the client

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -57,6 +57,10 @@ DJFS = {
     'url_root': '/static/djpyfs',
 }
 
+############################# ADVANCED COMPONENTS #############################
+FEATURES['ENABLE_CREATOR_GROUP'] = True
+
+
 ################################# CELERY ######################################
 
 # By default don't use a worker, execute tasks as if they were local functions

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -3,6 +3,11 @@
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangolib.markup import HTML, Text
+
+from opaque_keys.edx.keys import CourseKey
+
+from student.roles import CourseRerunCreatorRole, OrgRerunCreatorRole, OrgCourseCreatorRole, UserBasedRole
+
 %>
 
 <%inherit file="base.html" />
@@ -10,6 +15,7 @@ from openedx.core.djangolib.markup import HTML, Text
 <%def name="online_help_token()"><% return "home" %></%def>
 <%block name="title">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</%block>
 <%block name="bodyclass">is-signedin index view-dashboard</%block>
+
 
 <%block name="requirejs">
   require(["js/factories/index"], function (IndexFactory) {
@@ -22,12 +28,25 @@ from openedx.core.djangolib.markup import HTML, Text
   <header class="mast has-actions">
     <h1 class="page-header">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</h1>
 
+    <%
+      org_course_creator_status = 'notgranted'
+      org_course_creator_allowed_org = []
+
+      all_roles = UserBasedRole(request.user, 'org_course_creator_group').courses_with_role()
+      if all_roles:
+          org_course_creator_status = 'granted'
+          org_course_creator_allowed_org = [x.org for x in all_roles]
+      else:
+          org_course_creator_status = 'notgranted'
+          org_course_creator_allowed_org = []
+    %>
+
     % if user.is_active:
     <nav class="nav-actions" aria-label="${_('Page Actions')}">
       <h3 class="sr">${_("Page Actions")}</h3>
       <ul>
         <li class="nav-item">
-          % if course_creator_status=='granted':
+          % if course_creator_status=='granted' or org_course_creator_status=='granted':
           <a href="#" class="button new-button new-course-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span>
               ${_("New Course")}</a>
           % elif course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
@@ -49,7 +68,7 @@ from openedx.core.djangolib.markup import HTML, Text
   <section class="content">
     <article class="content-primary" role="main">
 
-      % if course_creator_status=='granted':
+      % if course_creator_status=='granted' or org_course_creator_status=='granted':
       <div class="wrapper-create-element wrapper-create-course">
         <form class="form-create create-course course-info" id="create-course-form" name="create-course-form">
           <div class="wrap-error">
@@ -77,12 +96,20 @@ from openedx.core.djangolib.markup import HTML, Text
                   <label for="new-course-org">${_("Organization")}</label>
                   ## Translators: This is an example for the name of the organization sponsoring a course, seen when filling out the form to create a new course. The organization name cannot contain spaces.
                   ## Translators: "e.g. UniversityX or OrganizationX" is a placeholder displayed when user put no data into this field.
-                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
+                  % if org_course_creator_allowed_org:
+                  <select class="new-course-org" id="new-course-org" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
+                    %for org in org_course_creator_allowed_org:
+                    <option value="${ org }">${ org }</option>
+                    %endfor
+                  </select>
+                  % else:
+                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org"/>
                   <span class="tip" id="tip-new-course-org">${Text(_("The name of the organization sponsoring the course. {strong_start}Note: The organization name is part of the course URL.{strong_end} This cannot be changed, but you can set a different display name in Advanced Settings later.")).format(
                       strong_start=HTML('<strong>'),
                       strong_end=HTML('</strong>'),
                   )}</span>
                   <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
+                  % endif
                 </li>
 
                 <li class="field text required" id="field-course-number">
@@ -208,7 +235,7 @@ from openedx.core.djangolib.markup import HTML, Text
       %endif
 
       <!-- STATE: processing courses -->
-      %if allow_course_reruns and rerun_creator_status and len(in_process_course_actions) > 0:
+      % if allow_course_reruns and rerun_creator_status and len(in_process_course_actions) > 0:
       <div class="courses courses-processing">
           <h3 class="title">${_("Courses Being Processed")}</h3>
 
@@ -311,7 +338,7 @@ from openedx.core.djangolib.markup import HTML, Text
             %endfor
           </ul>
       </div>
-      %endif
+      % endif
 
       % if libraries_enabled:
       <ul id="course-index-tabs">
@@ -321,6 +348,7 @@ from openedx.core.djangolib.markup import HTML, Text
       % endif
 
       %if len(courses) > 0 or optimization_enabled:
+
       <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
@@ -343,7 +371,10 @@ from openedx.core.djangolib.markup import HTML, Text
             </a>
 
             <ul  class="item-actions course-actions">
-              % if allow_course_reruns and rerun_creator_status and course_creator_status=='granted':
+              <%
+              show_link = (rerun_creator_status and course_creator_status=='granted') or CourseRerunCreatorRole( CourseKey.from_string(course_info['course_key']) ).has_user(request.user) or OrgRerunCreatorRole( course_info['org'] ).has_user(request.user)
+              %>
+              % if allow_course_reruns and show_link:
               <li class="action action-rerun">
                 <a href="${course_info['rerun_link']}" class="button rerun-button">${_("Re-run Course")}</a>
               </li>
@@ -357,7 +388,7 @@ from openedx.core.djangolib.markup import HTML, Text
         </ul>
       </div>
 
-      %else:
+      % else:
       <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
         <div class="notice-item">
           <div class="msg">
@@ -368,7 +399,7 @@ from openedx.core.djangolib.markup import HTML, Text
           </div>
         </div>
 
-        %if course_creator_status == "granted":
+        %if course_creator_status == "granted" or org_course_creator_status=='granted':
         <div class="notice-item has-actions">
           <div class="msg">
             <h3 class="title">${_('Create Your First Course')}</h3>
@@ -389,7 +420,7 @@ from openedx.core.djangolib.markup import HTML, Text
       % endif
 
 
-      %if course_creator_status == "unrequested":
+      %if course_creator_status == "unrequested" and (course_creator_status != "granted" and org_course_creator_status != "granted"):
       <div class="wrapper wrapper-creationrights">
         <h3 class="title">
           <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in {studio_name}').format(studio_name=settings.STUDIO_SHORT_NAME)}</span> <span class="icon fa fa-times-circle" aria-hidden="true"></span></a>
@@ -600,6 +631,6 @@ from openedx.core.djangolib.markup import HTML, Text
     </aside>
   </section>
 
-  %endif
+  % endif
 </div>
 </%block>

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -288,6 +288,33 @@ class CourseBetaTesterRole(CourseRole):
 
 
 @register_access_role
+class CourseRerunCreatorRole(CourseRole):
+    """A course staff with ability to rerun"""
+    ROLE = 'rerun_creator'
+
+    def __init__(self, *args, **kwargs):
+        super(CourseRerunCreatorRole, self).__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
+class OrgRerunCreatorRole(OrgRole):
+    """An ORG staff with ability to rerun all courses"""
+    ROLE = 'org_rerun_creator_group'
+
+    def __init__(self, *args, **kwargs):
+        super(OrgRerunCreatorRole, self).__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
+class OrgCourseCreatorRole(OrgRole):
+    """An ORG staff with ability to create new courses"""
+    ROLE = 'org_course_creator_group'
+
+    def __init__(self, *args, **kwargs):
+        super(OrgCourseCreatorRole, self).__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
 class LibraryUserRole(CourseRole):
     """
     A user who can view a library and import content from it, but not edit it.


### PR DESCRIPTION
---
This commit squashes a history trail:

BC-14: support for Course and OrgLevel permissions at the course rerun handlers

    Adding support for Course and OrgLevel permissions at the course rerun handlers
    From 4296905

    refactor has_access for user_has_role
    From 452c8fef

    Supporting the front end of the org_course_creator role
    From 4520e382

(cherry picked from commit 2905b10313faf0beb5fa5fb34aaf43532d90aec8)