### PR TITLE
gi/ednx/HE Enable HTML emails

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -5,7 +5,9 @@ import re
 from importlib import import_module
 
 from django import forms
-from django.conf import settings
+from openedx_email_extensions.utils import get_html_message
+
+from openedx.conf import settings
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User
@@ -93,7 +95,8 @@ class PasswordResetFormNoActive(PasswordResetForm):
             # Email subject *must not* contain newlines
             subject = subject.replace('\n', '')
             email = loader.render_to_string(email_template_name, context)
-            send_mail(subject, email, from_email, [user.email])
+            send_mail(subject, email, from_email, [user.email],
+                      html_message=get_html_message(context, base=email_template_name))
 
 
 class TrueCheckbox(widgets.CheckboxInput):

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -13,14 +13,14 @@ log = logging.getLogger('edx.celery.task')
 
 
 @task(bind=True)
-def send_activation_email(self, subject, message, from_address, dest_addr):
+def send_activation_email(self, subject, message, from_address, dest_addr, html_message):
     """
     Sending an activation email to the user.
     """
     max_retries = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS
     retries = self.request.retries
     try:
-        mail.send_mail(subject, message, from_address, [dest_addr], fail_silently=False)
+        mail.send_mail(subject, message, from_address, [dest_addr], fail_silently=False, html_message=html_message)
         # Log that the Activation Email has been sent to user without an exception
         log.info("Activation Email has been sent to User {user_email}".format(
             user_email=dest_addr

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -4,7 +4,7 @@ Tests for the Sending activation email celery tasks
 
 import mock
 from boto.exception import NoAuthHandlerFound
-from django.conf import settings
+from openedx.conf import settings
 from django.test import TestCase
 
 from lms.djangoapps.courseware.tests.factories import UserFactory
@@ -31,7 +31,7 @@ class SendActivationEmailTestCase(TestCase):
         email_max_attempts = settings.RETRY_ACTIVATION_EMAIL_MAX_ATTEMPTS
 
         # pylint: disable=no-member
-        send_activation_email.delay('Task_test', 'Task_test_message', from_address, self.student.email)
+        send_activation_email.delay('Task_test', 'Task_test_message', from_address, self.student.email, 'Task_test_html_message')
 
         # Asserts sending email retry logging.
         for attempt in range(email_max_attempts):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -12,7 +12,7 @@ from urlparse import parse_qs, urlsplit, urlunsplit
 
 import analytics
 import edx_oauth2_provider
-from django.conf import settings
+from openedx.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.decorators import login_required
@@ -47,6 +47,7 @@ from ratelimitbackend.exceptions import RateLimitException
 from requests import HTTPError
 from social_core.backends import oauth as social_oauth
 from social_core.exceptions import AuthAlreadyAssociated, AuthException
+from openedx_email_extensions.utils import get_html_message
 from social_django import utils as social_utils
 
 import dogstats_wrapper as dog_stats_api
@@ -604,13 +605,14 @@ def compose_and_send_activation_email(user, profile, user_registration=None):
     # Email subject *must not* contain newlines
     subject = ''.join(subject.splitlines())
     message_for_activation = render_to_string('emails/activation_email.txt', context)
+    html_message = get_html_message(context, base='emails/activation_email.txt')
     from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS', from_address)
     if settings.FEATURES.get('REROUTE_ACTIVATION_EMAIL'):
         dest_addr = settings.FEATURES['REROUTE_ACTIVATION_EMAIL']
         message_for_activation = ("Activation for %s (%s): %s\n" % (user, user.email, profile.name) +
                                   '-' * 80 + '\n\n' + message_for_activation)
-    send_activation_email.delay(subject, message_for_activation, from_address, dest_addr)
+    send_activation_email.delay(subject, message_for_activation, from_address, dest_addr, html_message)
 
 
 @login_required
@@ -2611,11 +2613,12 @@ def reactivation_email_for_user(user):
     subject = render_to_string('emails/activation_email_subject.txt', context)
     subject = ''.join(subject.splitlines())
     message = render_to_string('emails/activation_email.txt', context)
+    html_message = get_html_message(context, base='emails/activation_email.txt')
     from_address = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     from_address = configuration_helpers.get_value('ACTIVATION_EMAIL_FROM_ADDRESS', from_address)
 
     try:
-        user.email_user(subject, message, from_address)
+        user.email_user(subject, message, from_address, html_message=html_message)
     except Exception:  # pylint: disable=broad-except
         log.error(
             u'Unable to send reactivation email from "%s" to "%s"',
@@ -2679,13 +2682,14 @@ def do_email_change_request(user, new_email, activation_key=None):
     subject = ''.join(subject.splitlines())
 
     message = render_to_string('emails/email_change.txt', context)
+    html_message = get_html_message(context, base='emails/email_change.txt')
 
     from_address = configuration_helpers.get_value(
         'email_from_address',
         settings.DEFAULT_FROM_EMAIL
     )
     try:
-        mail.send_mail(subject, message, from_address, [pec.new_email])
+        mail.send_mail(subject, message, from_address, [pec.new_email], html_message=html_message)
     except Exception:  # pylint: disable=broad-except
         log.error(u'Unable to send email activation link to user from "%s"', from_address, exc_info=True)
         raise ValueError(_('Unable to send email activation link. Please try again later.'))
@@ -2732,6 +2736,7 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
         subject = render_to_string('emails/email_change_subject.txt', address_context)
         subject = ''.join(subject.splitlines())
         message = render_to_string('emails/confirm_email_change.txt', address_context)
+        html_message = get_html_message(address_context, base='emails/confirm_email_change.txt')
         u_prof = UserProfile.objects.get(user=user)
         meta = u_prof.get_meta()
         if 'old_emails' not in meta:
@@ -2744,7 +2749,8 @@ def confirm_email_change(request, key):  # pylint: disable=unused-argument
             user.email_user(
                 subject,
                 message,
-                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
+                configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL),
+                html_message=html_message,
             )
         except Exception:    # pylint: disable=broad-except
             log.warning('Unable to send confirmation email to old address', exc_info=True)

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -36,6 +36,8 @@ from track.event_transaction_utils import (
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
+from openedx_email_extensions.utils import get_html_message
+
 log = logging.getLogger(__name__)
 
 
@@ -472,7 +474,7 @@ def send_mail_to_student(student, param_dict, language=None):
 
     subject_template, message_template = email_template_dict.get(message_type, (None, None))
     if subject_template is not None and message_template is not None:
-        subject, message = render_message_to_string(
+        subject, message, html_message = render_message_to_string(
             subject_template, message_template, param_dict, language=language
         )
 
@@ -487,7 +489,8 @@ def send_mail_to_student(student, param_dict, language=None):
             settings.DEFAULT_FROM_EMAIL
         )
 
-        send_mail(subject, message, from_address, [student], fail_silently=False)
+        send_mail(subject, message, from_address, [student], fail_silently=False,
+                  html_message=html_message)
 
 
 def render_message_to_string(subject_template, message_template, param_dict, language=None):
@@ -510,7 +513,7 @@ def get_subject_and_message(subject_template, message_template, param_dict):
     """
     subject = render_to_string(subject_template, param_dict)
     message = render_to_string(message_template, param_dict)
-    return subject, message
+    return subject, message, get_html_message(param_dict, base=message_template)
 
 
 def uses_shib(course):

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -826,7 +826,7 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         )
 
     def test_subject_and_message_translation(self):
-        subject, message = self.get_subject_and_message('fr')
+        subject, message, html = self.get_subject_and_message('fr')
         language_after_rendering = get_language()
 
         you_have_been_invited_in_french = u"Vous avez été invité"
@@ -836,7 +836,7 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
 
     def test_platform_language_is_used_for_logged_in_user(self):
         with override_language('zh_CN'):    # simulate a user login
-            subject, message = self.get_subject_and_message(None)
+            subject, message, html = self.get_subject_and_message(None)
             self.assertIn("You have been", subject)
             self.assertIn("You have been", message)
 
@@ -849,7 +849,7 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         subject_template = 'emails/enroll_email_enrolledsubject.txt'
         message_template = 'emails/enroll_email_enrolledmessage.txt'
 
-        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        subject, message, html = self.get_subject_and_message_ccx(subject_template, message_template)
         self.assertIn(self.ccx.display_name, subject)
         self.assertIn(self.ccx.display_name, message)
         site = settings.SITE_NAME
@@ -868,7 +868,7 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         subject_template = 'emails/unenroll_email_subject.txt'
         message_template = 'emails/unenroll_email_enrolledmessage.txt'
 
-        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        subject, message, html = self.get_subject_and_message_ccx(subject_template, message_template)
         self.assertIn(self.ccx.display_name, subject)
         self.assertIn(self.ccx.display_name, message)
 
@@ -881,7 +881,7 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         subject_template = 'emails/enroll_email_allowedsubject.txt'
         message_template = 'emails/enroll_email_allowedmessage.txt'
 
-        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        subject, message, html = self.get_subject_and_message_ccx(subject_template, message_template)
         self.assertIn(self.ccx.display_name, subject)
         self.assertIn(self.ccx.display_name, message)
         site = settings.SITE_NAME
@@ -897,6 +897,6 @@ class TestRenderMessageToString(SharedModuleStoreTestCase):
         subject_template = 'emails/unenroll_email_subject.txt'
         message_template = 'emails/unenroll_email_allowedmessage.txt'
 
-        subject, message = self.get_subject_and_message_ccx(subject_template, message_template)
+        subject, message, html = self.get_subject_and_message_ccx(subject_template, message_template)
         self.assertIn(self.ccx.display_name, subject)
         self.assertIn(self.ccx.display_name, message)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -227,6 +227,7 @@ FEATURES = {
 
     # Turn on/off Microsites feature
     'USE_MICROSITES': False,
+    'ENABLE_MULTIPART_EMAIL': False,
     'USE_MICROSITE_AVAILABLE_SCREEN': True,
 
     # Turn on third-party auth. Disabled for now because full implementations are not yet available. Remember to syncdb

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -39,7 +39,9 @@ for log_name, log_level in LOG_OVERRIDES:
 
 ################################ EMAIL ########################################
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+EMAIL_FILE_PATH = REPO_ROOT / "email-messages"
+FEATURES['ENABLE_MULTIPART_EMAIL'] = True
 
 ########################## ANALYTICS TESTING ########################
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -7,7 +7,7 @@ from unittest import skipUnless, SkipTest
 import ddt
 import httpretty
 import mock
-from django.conf import settings
+from openedx.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
This PR enable HTML format in emails.

### How to testing:

Click on forget password in login screen, will appears a folder called email-messages with .log extension, change .log to .html and open the file in a browser. It must have text and html version.

