### PR TITLE
gi/ednx/FEC-10 | Marketing redirects

### DIFF
--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -13,6 +13,7 @@ from mako.exceptions import TopLevelLookupException
 
 from edxmako.shortcuts import render_to_response, render_to_string
 from util.cache import cache_if_anonymous
+from microsite_configuration import microsite
 
 valid_templates = []
 
@@ -41,6 +42,9 @@ def render(request, template):
 
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
+    mktg_redirects = microsite.get_value('MKTG_REDIRECTS', {})
+    if template in mktg_redirects and mktg_redirects.get(template):
+        return redirect(mktg_redirects.get(template, '/'))
 
     # Guess content type from file extension
     content_type, __ = mimetypes.guess_type(template)


### PR DESCRIPTION
This PR lets the microsite has custom redirects (privacy, tos ..).

To test this, add in a microsite
http://0.0.0.0:8000/admin/ednx_microsites/microsite/

 "MKTG_REDIRECTS": {
        "privacy.html": "http://host.domain/privacy-policy", 
        "tos.html": "http://host.domain/terms"
  },  
    2. Go to http://{microsite}/tos
    3. Check the redirect works
