### PR TITLE
Adding support for gtag in addition to google_analytics

### DIFF
--- a/lms/templates/google_analytics.html
+++ b/lms/templates/google_analytics.html
@@ -22,3 +22,15 @@ from microsite_configuration import microsite
 
 </script>
 % endif
+
+## <!-- Global site tag (gtag.js) - Google Analytics -->
+<% gtag_id = microsite.get_value('google_analytics_gtag', False) %>
+% if gtag_id:
+<script async src="https://www.googletagmanager.com/gtag/js?id=${ gtag_id|h }"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '${ gtag_id|h }');
+</script>
+% endif


### PR DESCRIPTION
# Description

This PR adds support for the gtag script on selected sites. Basically we add another google analytics script if the microsite has the `google_analytics_gtag` value.

# Reviewers
- [x] @Bound3R 
- [ ] @jfavellar90 

# Stakeholders

@Albeiro514