### PR TITLE
ADFS metadata has one key for encryption and one for signing

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -149,6 +149,12 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"), "[@use='signing']", "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
+    ))
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
# Description
To validate the responses we need the signing key and not only the first key in the metadata

This PR solves exactly that. It is also upstream material, but I want to see it working in production for a while first.

# Reviewers

- [x] @jfavellar90 

