### PR TITLE
Gi/ednx/ffi 8 2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -78,7 +78,6 @@ MySQL-python==1.2.5
 networkx==1.7
 nose-xunitmp==0.3.2
 oauthlib==1.0.3
-paramiko==1.9.0
 path.py==8.2.1
 piexif==1.0.2
 Pillow==3.4
@@ -94,10 +93,6 @@ python-memcached==1.48
 django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
-# This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
-# When this dependency gets upgraded, the monkey patch should be removed, if possible.
-# We can also remove the fix to auth_url in third_party_auth/saml.py when that fix is included upstream.
-python-social-auth==0.2.12
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
 pytz==2016.7
@@ -169,7 +164,6 @@ factory_boy==2.8.1
 flaky==3.3.0
 freezegun==0.3.8
 mock==1.0.1
-mock-django==0.6.9
 moto==0.3.1
 needle==0.5.0
 nose==1.3.7


### PR DESCRIPTION
# Desc

This PR reverts the changes done to requirements/edxapp/base.txt to leave it in the same state as ginkgo.master. It only maintains the `django-filter==0.13.0` dependency needed for the `data-api`

# Reviewers

- [ ] @jfavellar90 
- [ ] @ericfab179