### PR TITLE
Using the proxy settings object at the xmodule module_render and runtime

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -10,7 +10,7 @@ from functools import partial
 
 import newrelic.agent
 from capa.xqueue_interface import XQueueInterface
-from django.conf import settings
+from openedx.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.context_processors import csrf

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -1,7 +1,7 @@
 """
 Module implementing `xblock.runtime.Runtime` functionality for the LMS
 """
-from django.conf import settings
+from openedx.conf import settings
 from django.core.urlresolvers import reverse
 
 from badges.service import BadgingService


### PR DESCRIPTION
Backport from commit cfe2f516759ae63eed7cd85a0527d86b0e94ff26

This PR makes sure that the LTI (in fact any xblock) correctly exposes the hostname, so that multi-tenancy is real 