### PR TITLE
ednx/GI-13 | Tighter regex for course filter at index

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -530,7 +530,7 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            course_overviews = course_overviews.filter(org__iregex=r'(^' + '$|^'.join(orgs) + '$)')
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
This PR makes the regex used for search courses that will land in the homepage more strict. It has to have the complete name and nothing more.

Before this change, an org like EXA would also match in the org EXAMPLE.