### PR TITLE
JD-1 update

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -348,10 +348,12 @@ class OAuth2ProviderConfig(ProviderConfig):
         }
         """
         enabled_providers = microsite.get_value('THIRD_PARTY_AUTH_ENABLED_PROVIDERS', {})
+        if not enabled_providers:
+            return super(OAuth2ProviderConfig, cls).current(*args)
         provider_slug = enabled_providers.get(args[0])
         if provider_slug:
             return super(OAuth2ProviderConfig, cls).current(provider_slug)
-        return super(OAuth2ProviderConfig, cls).current(*args)
+        return super(OAuth2ProviderConfig, cls).current(None)
 
     def clean(self):
         """ Standardize and validate fields """


### PR DESCRIPTION
# Description
The current configuration will now use None as the seed for non-existant provider_slugs

This means that sites that do not have a `THIRD_PARTY_AUTH_ENABLED_PROVIDERS` will try to find the configuration as they would normally do, but sites that do have the configuration will only use the slugs available at the THIRD_PARTY_AUTH_ENABLED_PROVIDERS dict.

This ultimately fixes the situation where the same provider was available multiple times on the same site.

# Extra info

The JD-1 document in drive holds the remaining info of the feature

# Reviewers
- [x] @diegomillan 
- [ ] @jfavellar90 