### PR TITLE
bumping social-auth-core to 1.7.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ django-memcached-hashring==0.1.2
 python-openid==2.2.5
 python-dateutil==2.1
 social-auth-app-django==1.2.0
-social-auth-core==1.6.0 # Upgraded to fix Facebook Auth
+social-auth-core==1.7.0 # Upgraded to fix Facebook/Linkedin Auth
 pytz==2016.7
 pysrt==0.4.7
 PyYAML==3.12


### PR DESCRIPTION
The Linkedin auth is broken in the social-auth-core 1.6.0 version, so we need to do this upgrade