### PR TITLE
Fixing the studio lang selector

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -67,7 +67,7 @@ from openedx.core.djangoapps.lang_pref.api import released_languages
             function handleLangSelection(event) {
                 var $select = $(this);
                 var lang = $select.val();
-                $.cookie('${ settings.LANGUAGE_COOKIE }', lang, { expires: '', path: '' });
+                $.cookie('${ settings.LANGUAGE_COOKIE }', lang, { expires: '', path: '/' });
                 window.document.location.reload();
             }
             $("#footer-language-select").change(handleLangSelection);


### PR DESCRIPTION
This PR makes sure that the cookie is on the / path

Without this change when the user change the language at one page under studio.domain.com/some/path, the cookie gets set incorrectly