### PR TITLE
Fixing azuread logins

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -348,6 +348,14 @@ class OAuth2ProviderConfig(ProviderConfig):
         }
         """
         enabled_providers = microsite.get_value('THIRD_PARTY_AUTH_ENABLED_PROVIDERS', {})
+        # In a very specific case, azuread-oauth2 does not have a microsite context
+        if not microsite.is_request_in_microsite():
+            try:
+                microsite.set_by_domain(get_current_request().site.domain)
+                enabled_providers = microsite.get_value('THIRD_PARTY_AUTH_ENABLED_PROVIDERS', {})
+                microsite.clear()
+            except Exception:
+                pass
         if not enabled_providers:
             return super(OAuth2ProviderConfig, cls).current(*args)
         provider_slug = enabled_providers.get(args[0])


### PR DESCRIPTION
After carefully reviewing the calls to the azuread oauth2 pipeline I discovered some of them are not in a microsited request.

This PR makes sure that we activate the microsite context before running the provider selection functions.
