### PR TITLE
Bumping email extensions to fix es-419 charset

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -8,6 +8,6 @@
 -r custom.txt
 
 # For HTML email:
-git+https://github.com/eduNEXT/openedx-email-extensions.git@v0.1.5#egg=openedx-email-extensions==0.1.5
+git+https://github.com/eduNEXT/openedx-email-extensions.git@v0.1.6#egg=openedx-email-extensions==0.1.6
 # For general Edunext extensions
 git+https://github.com/eduNEXT/edunext-openedx-extensions@v0.7.0#egg=edunext-openedx-extensions==0.7.0


### PR DESCRIPTION
This PR bumps the openedx-email-extensions package to pull the latest translations fixes