### PR TITLE
Using a patched version of lti_consumer

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -86,7 +86,7 @@ git+https://github.com/edx/edx-milestones.git@v0.1.10#egg=edx-milestones==0.1.10
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.1#egg=edx-user-state-client==1.0.1
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.5#egg=lti_consumer-xblock==1.1.5
+git+https://github.com/edunext/xblock-lti-consumer.git@028076fc7a2eb7549049d7a20d96ccb361b49346#egg=lti_consumer-xblock==1.1.8-patch1
 git+https://github.com/edx/edx-proctoring.git@0.18.1#egg=edx-proctoring==0.18.1
 
 # Third Party XBlocks


### PR DESCRIPTION
This PR changes the lti_consumer to a modified version that supports sending the full name of the user to a third party service.

The relevant [commit](https://github.com/eduNEXT/xblock-lti-consumer/commit/028076fc7a2eb7549049d7a20d96ccb361b49346)

This PR has been tested on [stage](https://demo-edunext-io-ginkgo.edunext.co/courses/course-v1:demo-courses+DM101+2017/courseware/73a7847e74ef4e34aedc9205e97c8faa/28810607e9ae4e979a1d83497c5495c5/?activate_block_id=block-v1%3Ademo-courses%2BDM101%2B2017%2Btype%40sequential%2Bblock%4028810607e9ae4e979a1d83497c5495c5) and the resulting call to the bb service fails for a completely different reason. This is related to the domain of stage not being whitelisted.

The information passed to bb can be seen in `view-source:https://demo-edunext-io-ginkgo.edunext.co/courses/course-v1:demo-courses+DM101+2017/xblock/block-v1:demo-courses+DM101+2017+type@lti_consumer+block@9882c346a6de4e20a29e708a3991ac73/handler/lti_launch_handler`
