### PR TITLE
Lmm/edunextack

### DIFF
--- a/cms/envs/ednx_devstack.py
+++ b/cms/envs/ednx_devstack.py
@@ -1,0 +1,3 @@
+""" Overrides for Docker-based eduNEXT devstack. """
+
+from .devstack_docker import *  # pylint: disable=wildcard-import, unused-wildcard-import

--- a/lms/envs/ednx_devstack.py
+++ b/lms/envs/ednx_devstack.py
@@ -1,0 +1,3 @@
+""" Overrides for Docker-based eduNEXT devstack. """
+
+from .devstack_docker import *  # pylint: disable=wildcard-import, unused-wildcard-import

--- a/lms/envs/ednx_devstack.py
+++ b/lms/envs/ednx_devstack.py
@@ -1,3 +1,13 @@
 """ Overrides for Docker-based eduNEXT devstack. """
 
 from .devstack_docker import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+
+LOGGING['handlers']['tracking'] = {
+    'level': 'DEBUG',
+    'class': 'logging.FileHandler',
+    'filename': '/edx/var/log/tracking/tracking.log',
+    'formatter': 'raw',
+    }
+
+LOGGING['loggers']['tracking']['handlers'] = ['tracking']


### PR DESCRIPTION
To test this, change in the  docker devstack the docker-compose.yml file the LMS command and STUDIO command to use the ednx_devstack settings

```
  lms:
    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings ednx_devstack; sleep 2; done'
...
  studio:
    command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py cms runserver 0.0.0.0:18010 --settings ednx_devstack; sleep 2; done'
```

Then access to the lms and see how the trackinglogs are being logged.

`tailf /edx/var/log/tracking/tracking.log `

 