### PR TITLE
Ha/ednx/bfh - Remove the forum notifier

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
+++ b/lms/djangoapps/discussion/static/discussion/templates/discussion-home.underscore
@@ -6,44 +6,44 @@
     <% } %>
   </section>
 
-  <% if (window.ENABLE_DISCUSSION_HOME_PANEL) { %>
-    <span class="label label-settings">
-      <%- interpolate(
-            gettext("How to use %(platform_name)s discussions"),
-            {platform_name: window.PLATFORM_NAME}, true
-          ) %>
-    </span>
-    <table class="home-helpgrid">
-      <tr class="helpgrid-row helpgrid-row-navigation">
-        <th scope="row" class="row-title"><%- gettext("Find discussions") %></td>
-        <td class="row-item">
-          <span class="icon fa fa-reorder" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Use the All Topics menu to find specific topics.") %></span>
-        </td>
-        <td class="row-item">
-          <span class="icon fa fa-search" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Search all posts") %></span>
-        </td>
-        <td class="row-item">
-          <span class="icon fa fa-sort" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Filter and sort topics") %></span>
-        </td>
-      </tr>
-      <tr class="helpgrid-row helpgrid-row-participation">
-        <th scope="row" class="row-title"><%- gettext("Engage with posts") %></td>
-        <td class="row-item">
-          <span class="icon fa fa-plus" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Vote for good posts and responses") %></span>
-        </td>
-        <td class="row-item">
-          <span class="icon fa fa-flag" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Report abuse, topics, and responses") %></span>
-        </td>
-        <td class="row-item">
-          <span class="icon fa fa-star" aria-hidden="true"></span>
-          <span class="row-description"><%- gettext("Follow or unfollow posts") %></span>
-        </td>
-      </tr>
+  <span class="label label-settings">
+    <%- interpolate(
+          gettext("How to use %(platform_name)s discussions"),
+          {platform_name: window.PLATFORM_NAME}, true
+        ) %>
+  </span>
+  <table class="home-helpgrid">
+    <tr class="helpgrid-row helpgrid-row-navigation">
+      <th scope="row" class="row-title"><%- gettext("Find discussions") %></td>
+      <td class="row-item">
+        <span class="icon fa fa-reorder" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Use the All Topics menu to find specific topics.") %></span>
+      </td>
+      <td class="row-item">
+        <span class="icon fa fa-search" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Search all posts") %></span>
+      </td>
+      <td class="row-item">
+        <span class="icon fa fa-sort" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Filter and sort topics") %></span>
+      </td>
+    </tr>
+    <tr class="helpgrid-row helpgrid-row-participation">
+      <th scope="row" class="row-title"><%- gettext("Engage with posts") %></td>
+      <td class="row-item">
+        <span class="icon fa fa-plus" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Vote for good posts and responses") %></span>
+      </td>
+      <td class="row-item">
+        <span class="icon fa fa-flag" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Report abuse, topics, and responses") %></span>
+      </td>
+      <td class="row-item">
+        <span class="icon fa fa-star" aria-hidden="true"></span>
+        <span class="row-description"><%- gettext("Follow or unfollow posts") %></span>
+      </td>
+    </tr>
+    <% if (window.ENABLE_DISCUSSION_HOME_PANEL) { %>
       <tr class="helpgrid-row helpgrid-row-notification">
         <th scope="row" class="row-title"><%- gettext('Receive updates') %></td>
         <td class="row-item-full" colspan="3">
@@ -57,6 +57,6 @@
           <span class="row-description"><%- gettext("Check this box to receive an email digest once a day notifying you about new, unread activity from posts you are following.") %></span>
         </td>
       </tr>
-    </table>
-  <% } %>
+    <% } %>
+  </table>
 </div>


### PR DESCRIPTION
## Description:

This PR moves the conditional block to discussion subscription block, in order to hide the subscription box, only if setting FEATURES['ENABLE_DISCUSSION_HOME_PANEL'] is False.

## Test:

Add to the devstack_docker.py file ENABLE_DISCUSSION_HOME_PANEL = False value in the FEATURES.update() function.

Then the discussion subscription block is not longer shown to the user.

## Reviewers:

 - [ ] @felipemontoya 
 - [ ] @diegomillan 