### PR TITLE
ha/ednx/GI-10 - Add validation for 'signing' key value.

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -170,6 +170,14 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"),
+        "[@use='signing']",
+        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
+    ))
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
## Description: 

This PR adds a validation to get the 'signing' key contained in the response.

## Reviewers:

- [ ] @diegomillan 
- [x] @felipemontoya 