### PR TITLE
ha/ednx/FEC-10 | MKTG redirects

### DIFF
--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -17,6 +17,7 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from util.cache import cache_if_anonymous
 from util.views import fix_crum_request
+from microsite_configuration import microsite
 
 valid_templates = []
 
@@ -45,6 +46,9 @@ def render(request, template):
 
     url(r'^jobs$', 'static_template_view.views.render', {'template': 'jobs.html'}, name="jobs")
     """
+    mktg_redirects = microsite.get_value('MKTG_REDIRECTS', {})
+    if template in mktg_redirects and mktg_redirects.get(template):
+        return redirect(mktg_redirects.get(template, '/'))
 
     # Guess content type from file extension
     content_type, __ = mimetypes.guess_type(template)


### PR DESCRIPTION
This PR allows to support custom marketing sites redirects (privacy, tos ..)

## Test:
Add the following config to your site:
"MKTG_REDIRECTS": {
"privacy.html": "http://host.domain/privacy-policy",
"tos.html": "http://host.domain/terms"
},
2. Go to http://{microsite}/tos
3. Check the redirect works

## Reviewers:
 
 - [x] @Squirrel18 