### PR TITLE
Reverting "Honor mode is not eligible for certificate"

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -686,16 +686,13 @@ class CourseMode(models.Model):
     def is_eligible_for_certificate(cls, mode_slug):
         """
         Returns whether or not the given mode_slug is eligible for a
-        certificate. Currently all modes other than 'audit' and `honor`
-        grant a certificate. Note that audit enrollments which existed
-        prior to December 2015 *were* given certificates, so there will
-        be GeneratedCertificate records with mode='audit' which are
+        certificate. Currently all modes other than 'audit' grant a
+        certificate. Note that audit enrollments which existed prior
+        to December 2015 *were* given certificates, so there will be
+        GeneratedCertificate records with mode='audit' which are
         eligible.
         """
-        if mode_slug == cls.AUDIT or mode_slug == cls.HONOR:
-            return False
-
-        return True
+        return mode_slug != cls.AUDIT
 
     def to_tuple(self):
         """

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -456,7 +456,7 @@ class CourseModeModelTest(TestCase):
 
     @ddt.data(
         (CourseMode.AUDIT, False),
-        (CourseMode.HONOR, False),
+        (CourseMode.HONOR, True),
         (CourseMode.VERIFIED, True),
         (CourseMode.CREDIT_MODE, True),
         (CourseMode.PROFESSIONAL, True),

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -90,7 +90,6 @@ class CertificateStatuses(object):
     auditing = 'auditing'
     audit_passing = 'audit_passing'
     audit_notpassing = 'audit_notpassing'
-    honor_passing = 'honor_passing'
     unverified = 'unverified'
     invalidated = 'invalidated'
     requesting = 'requesting'

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1338,7 +1338,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             course_id=self.course.id,
             status=CertificateStatuses.downloadable,
             download_url="",
-            mode='verified'
+            mode='honor'
         )
 
         # Enable the feature, but do not enable it for this course
@@ -1364,34 +1364,29 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.course.cert_html_view_enabled = True
         self.course.save()
         self.store.update_item(self.course, self.user.id)
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
 
-            with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-                course_grade = mock_create.return_value
-                course_grade.passed = True
-                course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = True
+            course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
 
-                resp = self._get_progress_page()
+            resp = self._get_progress_page()
 
-                self.assertContains(resp, u"View Certificate")
+            self.assertContains(resp, u"View Certificate")
 
-                self.assertContains(resp, u"earned a certificate for this course")
-                cert_url = certs_api.get_certificate_url(course_id=self.course.id, uuid=certificate.verify_uuid)
-                self.assertContains(resp, cert_url)
+            self.assertContains(resp, u"earned a certificate for this course")
+            cert_url = certs_api.get_certificate_url(course_id=self.course.id, uuid=certificate.verify_uuid)
+            self.assertContains(resp, cert_url)
 
-                # when course certificate is not active
-                certificates[0]['is_active'] = False
-                self.store.update_item(self.course, self.user.id)
+            # when course certificate is not active
+            certificates[0]['is_active'] = False
+            self.store.update_item(self.course, self.user.id)
 
-                resp = self._get_progress_page()
-                self.assertNotContains(resp, u"View Your Certificate")
-                self.assertNotContains(resp, u"You can now view your certificate")
-                self.assertContains(resp, "working on it...")
-                self.assertContains(resp, "creating your certificate")
+            resp = self._get_progress_page()
+            self.assertNotContains(resp, u"View Your Certificate")
+            self.assertNotContains(resp, u"You can now view your certificate")
+            self.assertContains(resp, "working on it...")
+            self.assertContains(resp, "creating your certificate")
 
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': False})
     def test_view_certificate_link_hidden(self):
@@ -1404,7 +1399,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             course_id=self.course.id,
             status=CertificateStatuses.downloadable,
             download_url="http://www.example.com/certificate.pdf",
-            mode='verified'
+            mode='honor'
         )
 
         # Enable the feature, but do not enable it for this course
@@ -1413,23 +1408,17 @@ class ProgressPageTests(ProgressPageBaseTests):
         # Enable certificate generation for this course
         certs_api.set_cert_generation_enabled(self.course.id, True)
 
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = True
+            course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
 
-            with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-                course_grade = mock_create.return_value
-                course_grade.passed = True
-                course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
-
-                resp = self._get_progress_page()
-                self.assertContains(resp, u"Download Your Certificate")
+            resp = self._get_progress_page()
+            self.assertContains(resp, u"Download Your Certificate")
 
     @ddt.data(
-        (True, 38),
-        (False, 37)
+        (True, 40),
+        (False, 39)
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
@@ -1440,8 +1429,8 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 45, 29),
-        (True, 37, 24)
+        (False, 47, 30),
+        (True, 39, 25)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):
@@ -1491,7 +1480,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
                 resp = self._get_progress_page()
 
-                cert_button_hidden = course_mode in (CourseMode.AUDIT, CourseMode.HONOR) or \
+                cert_button_hidden = course_mode is CourseMode.AUDIT or \
                     course_mode in CourseMode.VERIFIED_MODES and not user_verified
 
                 self.assertEqual(
@@ -1506,7 +1495,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         re-generate button should not appear on progress page.
         """
         generated_certificate = self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
 
         # Course certificate configurations
@@ -1525,22 +1514,17 @@ class ProgressPageTests(ProgressPageBaseTests):
         self.course.cert_html_view_enabled = True
         self.course.save()
         self.store.update_item(self.course, self.user.id)
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
 
-            with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-                course_grade = mock_create.return_value
-                course_grade.passed = True
-                course_grade.summary = {
-                    'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
-                }
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = True
+            course_grade.summary = {
+                'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
+            }
 
-                resp = self._get_progress_page()
-                self.assertContains(resp, u"View Certificate")
-                self.assert_invalidate_certificate(generated_certificate)
+            resp = self._get_progress_page()
+            self.assertContains(resp, u"View Certificate")
+            self.assert_invalidate_certificate(generated_certificate)
 
     @patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
     def test_page_with_whitelisted_certificate_with_html_view(self):
@@ -1549,7 +1533,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         appearing on dashboard
         """
         generated_certificate = self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
 
         # Course certificate configurations
@@ -1573,22 +1557,17 @@ class ProgressPageTests(ProgressPageBaseTests):
             course_id=self.course.id,
             whitelist=True
         )
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
 
-            with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-                course_grade = mock_create.return_value
-                course_grade.passed = False
-                course_grade.summary = {
-                    'grade': 'Fail', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
-                }
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = False
+            course_grade.summary = {
+                'grade': 'Fail', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}
+            }
 
-                resp = self._get_progress_page()
-                self.assertContains(resp, u"View Certificate")
-                self.assert_invalidate_certificate(generated_certificate)
+            resp = self._get_progress_page()
+            self.assertContains(resp, u"View Certificate")
+            self.assert_invalidate_certificate(generated_certificate)
 
     def test_page_with_invalidated_certificate_with_pdf(self):
         """
@@ -1596,22 +1575,17 @@ class ProgressPageTests(ProgressPageBaseTests):
         re-generate button should not appear on progress page.
         """
         generated_certificate = self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
 
-            with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-                course_grade = mock_create.return_value
-                course_grade.passed = True
-                course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
+        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
+            course_grade = mock_create.return_value
+            course_grade.passed = True
+            course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
 
-                resp = self._get_progress_page()
-                self.assertContains(resp, u'Download Your Certificate')
-                self.assert_invalidate_certificate(generated_certificate)
+            resp = self._get_progress_page()
+            self.assertContains(resp, u'Download Your Certificate')
+            self.assert_invalidate_certificate(generated_certificate)
 
     @patch('courseware.views.views.is_course_passed', PropertyMock(return_value=True))
     def test_message_for_audit_mode(self):
@@ -1634,33 +1608,12 @@ class ProgressPageTests(ProgressPageBaseTests):
                 u'You are enrolled in the audit track for this course. The audit track does not include a certificate.'
             )
 
-    @patch('courseware.views.views.is_course_passed', PropertyMock(return_value=True))
-    def test_message_for_honor_mode(self):
-        """ Verify that message appears on progress page, if learner is enrolled
-         in honor mode.
-        """
-        user = UserFactory.create()
-        self.assertTrue(self.client.login(username=user.username, password='test'))
-        CourseEnrollmentFactory(user=user, course_id=self.course.id, mode=CourseMode.HONOR)
-
-        with patch('lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read') as mock_create:
-            course_grade = mock_create.return_value
-            course_grade.passed = True
-            course_grade.summary = {'grade': 'Pass', 'percent': 0.75, 'section_breakdown': [], 'grade_breakdown': {}}
-
-            response = self._get_progress_page()
-
-            self.assertContains(
-                response,
-                u'You are enrolled in the honor track for this course. The honor track does not include a certificate.'
-            )
-
     def test_invalidated_cert_data(self):
         """
         Verify that invalidated cert data is returned if cert is invalidated.
         """
         generated_certificate = self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
 
         CertificateInvalidationFactory.create(
@@ -1669,7 +1622,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         )
         # Invalidate user certificate
         generated_certificate.invalidate()
-        response = views._get_cert_data(self.user, self.course, CourseMode.VERIFIED, MagicMock(passed=True))
+        response = views._get_cert_data(self.user, self.course, CourseMode.HONOR, MagicMock(passed=True))
         self.assertEqual(response.cert_status, 'invalidated')
         self.assertEqual(response.title, 'Your certificate has been invalidated')
 
@@ -1678,17 +1631,11 @@ class ProgressPageTests(ProgressPageBaseTests):
         Verify that downloadable cert data is returned if cert is downloadable.
         """
         self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
-
-            with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
-                       return_value=self.mock_certificate_downloadable_status(is_downloadable=True)):
-                response = views._get_cert_data(self.user, self.course, CourseMode.VERIFIED, MagicMock(passed=True))
+        with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
+                   return_value=self.mock_certificate_downloadable_status(is_downloadable=True)):
+            response = views._get_cert_data(self.user, self.course, CourseMode.HONOR, MagicMock(passed=True))
 
         self.assertEqual(response.cert_status, 'downloadable')
         self.assertEqual(response.title, 'Your certificate is available')
@@ -1698,11 +1645,11 @@ class ProgressPageTests(ProgressPageBaseTests):
         Verify that generating cert data is returned if cert is generating.
         """
         self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
         with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
                    return_value=self.mock_certificate_downloadable_status(is_generating=True)):
-            response = views._get_cert_data(self.user, self.course, CourseMode.VERIFIED, MagicMock(passed=True))
+            response = views._get_cert_data(self.user, self.course, CourseMode.HONOR, MagicMock(passed=True))
 
         self.assertEqual(response.cert_status, 'generating')
         self.assertEqual(response.title, "We're working on it...")
@@ -1712,11 +1659,11 @@ class ProgressPageTests(ProgressPageBaseTests):
         Verify that unverified cert data is returned if cert is unverified.
         """
         self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
         with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
                    return_value=self.mock_certificate_downloadable_status(is_unverified=True)):
-            response = views._get_cert_data(self.user, self.course, CourseMode.VERIFIED, MagicMock(passed=True))
+            response = views._get_cert_data(self.user, self.course, CourseMode.HONOR, MagicMock(passed=True))
 
         self.assertEqual(response.cert_status, 'unverified')
         self.assertEqual(response.title, "Certificate unavailable")
@@ -1726,16 +1673,11 @@ class ProgressPageTests(ProgressPageBaseTests):
         Verify that requested cert data is returned if cert is to be requested.
         """
         self.generate_certificate(
-            "http://www.example.com/certificate.pdf", "verified"
+            "http://www.example.com/certificate.pdf", "honor"
         )
-        CourseEnrollment.enroll(self.user, self.course.id, mode="verified")
-        with patch(
-                'lms.djangoapps.verify_student.services.IDVerificationService.user_is_verified'
-        ) as user_verify:
-            user_verify.return_value = True
-            with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
-                       return_value=self.mock_certificate_downloadable_status()):
-                response = views._get_cert_data(self.user, self.course, CourseMode.VERIFIED, MagicMock(passed=True))
+        with patch('lms.djangoapps.certificates.api.certificate_downloadable_status',
+                   return_value=self.mock_certificate_downloadable_status()):
+            response = views._get_cert_data(self.user, self.course, CourseMode.HONOR, MagicMock(passed=True))
 
         self.assertEqual(response.cert_status, 'requesting')
         self.assertEqual(response.title, "Congratulations, you qualified for a certificate!")

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -126,14 +126,6 @@ AUDIT_PASSING_CERT_DATA = CertData(
     cert_web_view_url=None
 )
 
-HONOR_PASSING_CERT_DATA = CertData(
-    CertificateStatuses.honor_passing,
-    _('Your enrollment: Honor track'),
-    _('You are enrolled in the honor track for this course. The honor track does not include a certificate.'),
-    download_url=None,
-    cert_web_view_url=None
-)
-
 GENERATING_CERT_DATA = CertData(
     CertificateStatuses.generating,
     _("We're working on it..."),
@@ -1057,7 +1049,7 @@ def _get_cert_data(student, course, enrollment_mode, course_grade=None):
         returns dict if course certificate is available else None.
     """
     if not CourseMode.is_eligible_for_certificate(enrollment_mode):
-        return AUDIT_PASSING_CERT_DATA if enrollment_mode == CourseMode.AUDIT else HONOR_PASSING_CERT_DATA
+        return AUDIT_PASSING_CERT_DATA
 
     certificates_enabled_for_course = certs_api.cert_generation_enabled(course.id)
     if course_grade is None:


### PR DESCRIPTION
Revert "Merge pull request #17428 from edx/ahsan/LEARNER-4117-update-eligible-for-cert"

This reverts commit a42c1f6904f180b410fb053c95605319ad06769f, reversing
changes made to b005276f680106ae8f5529390c9fbde091bf973d.

# Conflicts:
#	lms/djangoapps/courseware/tests/test_views.py

Now Honor mode is again eligible for certificate

@felipemontoya 
@diegomillan 
@Alec4r 