### PR TITLE
Bumping scorm xblock to fix root path issue

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -28,7 +28,7 @@ git+https://github.com/edx-solutions/xblock-brightcove.git@b8d13b6b3b0c3c31a3334
 
 # eduNEXT supported xblocks
 git+https://github.com/eduNEXT/flow-control-xblock.git@3040d00ce8aac13ad38c82789873f8b5d6cb7e62#egg=flow-control-xblock
-git+https://github.com/eduNEXT/edx_xblock_scorm.git@ce78ac13869b4014af26b258316231f6b0839d78#egg=scormxblock-xblock
+-e git+https://github.com/eduNEXT/edx_xblock_scorm.git@be7d4c420d843391c7e0fdbcb6de414ee9446fc5#egg=scormxblock-xblock
 git+https://github.com/eduNEXT/crm-integration-xblock.git@v1.6.0#egg=crm_integration_xblock==1.6.0
 # Patched version that includes the fullname
 git+https://github.com/edunext/xblock-lti-consumer.git@028076fc7a2eb7549049d7a20d96ccb361b49346#egg=lti_consumer-xblock==1.1.8-patch1


### PR DESCRIPTION
This is PR updates scorm xblock in order to get a root path correctly before uploading content to S3

@felipemontoya 
@jfavellar90 
@Alec4r 