### PR TITLE
Setting template to show currency defined in the course mode DB record

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -8,6 +8,7 @@ import urllib
 
 import waffle
 from babel.dates import format_datetime
+from babel.numbers import get_currency_symbol
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse
 from django.db import transaction
@@ -176,6 +177,7 @@ class ChooseModeView(View):
                 if x.strip()
             ]
             context["currency"] = verified_mode.currency.upper()
+            context["currency_symbol"] = get_currency_symbol(verified_mode.currency.upper())
             context["min_price"] = verified_mode.min_price
             context["verified_name"] = verified_mode.name
             context["verified_description"] = verified_mode.description

--- a/lms/templates/course_modes/choose.html
+++ b/lms/templates/course_modes/choose.html
@@ -104,7 +104,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                     <ul class="list-actions">
                                                         <li class="action action-select">
                                                             <input type="hidden" name="contribution" value="${min_price}" />
-                                                            <input type="submit" name="verified_mode" value="${_('Pursue a Verified Certificate')} ($${min_price} USD)" />
+                                                            <input type="submit" name="verified_mode" value="${_('Pursue a Verified Certificate')} (${currency_symbol}${min_price} ${currency})" />
                                                         </li>
                                                     </ul>
                                                 </div>
@@ -130,7 +130,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                     <ul class="list-actions">
                                                         <li class="action action-select">
                                                             <input type="hidden" name="contribution" value="${min_price}" />
-                                                            <input type="submit" name="verified_mode" value="${_('Pursue a Verified Certificate')} ($${min_price} USD)" />
+                                                            <input type="submit" name="verified_mode" value="${_('Pursue a Verified Certificate')} (${currency_symbol}${min_price} ${currency})" />
                                                         </li>
                                                     </ul>
                                                 </div>


### PR DESCRIPTION
This PR modifies the template in order to support custom currencies. Also, we convert a valid ISO 4217 currency code to its corresponding symbol. 

@felipemontoya 
@Squirrel18 
@jfavellar90 
@Alec4r 

Screenshots:
For a course with `usd` as currency

![dollar](https://user-images.githubusercontent.com/1813634/53138622-f8d8e600-3554-11e9-9949-c4c513db5b99.png)


For a course with `eur` as currency 

![eur](https://user-images.githubusercontent.com/1813634/53138632-fe363080-3554-11e9-9cb2-fca3241cc9a4.png)
