### PR TITLE
Updating social auth

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -127,8 +127,8 @@ pyuca==1.1                          # For more accurate sorting of translated co
 reportlab==3.1.44                   # Used for shopping cart's pdf invoice/receipt generation
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
-social-auth-app-django
-social-auth-core
+social-auth-app-django==3.1.0
+social-auth-core==3.0.0
 pysrt==0.4.7                        # Support for SubRip subtitle files, used in the video XModule
 pytz==2016.10                       # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -221,8 +221,8 @@ shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.16.0        # via django-rest-swagger, dogapi, mailsnake, sailthru-client, zendesk
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 stevedore==1.10.0


### PR DESCRIPTION
This PR updates social-auth-core and social-auth-app-django to the latest available versions as of today.

This will fix:
- errors on the third party auth sad path
- calling the deprecated google plus API

Keep in mind that this version is newer that what the upstream repo has, but we have tested this on a production grade installation with google, facebook linkedin and saml integrations without errors