### PR TITLE
Removing edunext private requirements file

### DIFF
--- a/requirements/edunext/private.txt
+++ b/requirements/edunext/private.txt
@@ -1,8 +1,0 @@
-# eduNEXT plugins:
-
-# plugins must be editable for the settings to appear on the sys path during loading
--e git+ssh://git@bitbucket.org/edunext/eox-manage.git@b8b4ee79a0e91b8c8bc40e67307970b0d397008f#egg=eox-manage
-
-# eduNEXT xblocks:
-git+ssh://git@bitbucket.org/edunext/sodexo_xblock.git@c2ea1f706b2ff2456637d25768ad54ef4f8df90e#egg=sodexo-game-xblock
-git+ssh://git@bitbucket.org/edunext/grade-podium-xblock.git@66730cc4fd3adf7263dbe94d2913164eb7c46fa6#egg=grade-podium-xblock


### PR DESCRIPTION
Removing edunext private requirements file, the private requirements are now handled through ansible with the variable EDXAPP_PRIVATE_REQUIREMENTS

@felipemontoya 
@diegomillan 
@Squirrel18 