### PR TITLE
Updating xblock poll version to 1.8.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -43,7 +43,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 alabaster==0.7.11         # via sphinx

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -101,5 +101,5 @@
 # Third Party XBlocks
 
 -e git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac96#egg=edx-sga==0.8.0
--e git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+-e git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -38,7 +38,7 @@ git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 amqp==1.4.9


### PR DESCRIPTION
Updating the xblock-poll to support correctly the download of poll and survey results through the button "download results to csv". Already tested in stage

@felipemontoya 
@Alec4r 
@diegomillan 
@Squirrel18 