### PR TITLE
Updating eox-core to 1.1.0

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -61,4 +61,4 @@ git+https://github.com/proversity-org/badgr-xblock.git@7077d499b2f752c78bb41e9c1
 ###################
 # plugins must be editable for the settings to appear on the sys path during loading
 -e git+https://github.com/eduNEXT/eox-tenant.git@v0.4.0#egg=eox-tenant==0.4.0
--e git+https://github.com/eduNEXT/eox-core.git@v1.0.0#egg=eox-core==1.0.0
+git+https://github.com/eduNEXT/eox-core.git@v1.1.0#egg=eox-core==1.1.0


### PR DESCRIPTION
This PR updates eox core after the feedback we got from production with customers.
It does not longer need to be installed in editable mode.