### PR TITLE
Disable html filter to avoid error on css extra inline.

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -35,5 +35,5 @@ from microsite_configuration import microsite
   <link rel="stylesheet" type="text/css" href="${static.url(style_overrides_file_extra)}" />
 % endif
 % if style_overrides_inline_extra:
-  <style type="text/css">${style_overrides_inline_extra}</style>
+  <style type="text/css">${style_overrides_inline_extra | n}</style>
 % endif


### PR DESCRIPTION
This PR disable html filter on head extra file to fix error with some characters on extra css code. Example:
![image](https://user-images.githubusercontent.com/36944773/61481790-9e568100-a95e-11e9-8020-febb1c062af5.png)
