### PR TITLE
Language selection LC-V2

### DIFF
--- a/lms/envs/ednx_devstack.py
+++ b/lms/envs/ednx_devstack.py
@@ -44,3 +44,11 @@ GRADES_DOWNLOAD = {
     'BUCKET': 'openedx-grades',
     'ROOT_PATH': '/edx/var/edxapp/uploads',
 }
+
+############################### LANG ########################
+
+LANGUAGE_CODE = 'en'
+TIME_ZONE = 'America/Bogota'
+FEATURES['SHOW_HEADER_LANGUAGE_SELECTOR'] = True
+FEATURES['SHOW_FOOTER_LANGUAGE_SELECTOR'] = True
+FEATURES['EDNX_SITE_AWARE_LOCALE'] = True

--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -71,10 +71,12 @@ class DarkLangMiddleware(object):
 
     def process_request(self, request):
         """
-        Prevent user from requesting un-released languages except by using the preview-lang query string.
+        eduNEXT: this middleware will always process the requests.
+        The model has been modified to not even attempt the db lookup
         """
-        if not DarkLangConfig.current().enabled:
-            return
+        if not settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
+            if not DarkLangConfig.current().enabled:
+                return
 
         self._clean_accept_headers(request)
         self._activate_preview_language(request)
@@ -97,8 +99,13 @@ class DarkLangMiddleware(object):
         Remove any language that is not either in ``self.released_langs`` or
         a territory of one of those languages.
         """
+        ednx_locale = settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False)
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', None)
         if accept is None or accept == '*':
+            if ednx_locale:
+                # eduNEXT: return the site aware settings.LANGUAGE_CODE
+                # so that django.utils.locale.LocaleMiddleware can pick it up
+                request.META['HTTP_ACCEPT_LANGUAGE'] = "{};q={}".format(settings.LANGUAGE_CODE, "0.1")
             return
 
         new_accept = []
@@ -107,6 +114,9 @@ class DarkLangMiddleware(object):
             if fuzzy_code:
                 # Formats lang and priority into a valid accept header fragment.
                 new_accept.append("{};q={}".format(fuzzy_code, priority))
+            elif ednx_locale:
+                # eduNEXT: if there is no match, we set it to the settings.LANGUAGE_CODE
+                new_accept.append("{};q={}".format(settings.LANGUAGE_CODE, "0.1"))
 
         new_accept = ", ".join(new_accept)
 

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -2,7 +2,9 @@
 Models for the dark-launching languages
 """
 from config_models.models import ConfigurationModel
+from django.conf import settings
 from django.db import models
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 class DarkLangConfig(ConfigurationModel):
@@ -23,9 +25,21 @@ class DarkLangConfig(ConfigurationModel):
         ``released_languages`` as a list of language codes.
 
         Example: ['it', 'de-at', 'es', 'pt-br']
+
+        eduNEXT: we support only the list of available languages from the site
+        otherwise is the same as having no configuration
         """
-        if not self.released_languages.strip():
-            return []
+        if settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
+            site_released_langs = configuration_helpers.get_value("released_languages", None)
+
+            # If there aren't any released_languages configured
+            if not site_released_langs:
+                site_released_langs = []
+            else:
+                site_released_langs = [lang.lower().strip() for lang in site_released_langs.split(',')]
+                site_released_langs.sort()
+
+            return site_released_langs
 
         languages = [lang.lower().strip() for lang in self.released_languages.split(',')]
         # Put in alphabetical order


### PR DESCRIPTION
This feature does a match between the languages that the user accepts -on their browser- and the languages available on this tenant. Ednxsite awareness for language selection. It replaces the regular DarkLang app with a ednxsite aware configuration.