### PR TITLE
Updating xblock poll version to 1.8.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -36,7 +36,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -39,7 +39,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 -e common/lib/xmodule
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -100,5 +100,5 @@
 # Third Party XBlocks
 
 -e git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
--e git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+-e git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 -e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -37,7 +37,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.0#egg=ora2==2.2.0
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@1.8.4#egg=xblock-poll==1.8.4
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.2.9


### PR DESCRIPTION
This PR updates the version of the xblock-poll to 1.8.4. This version fixes a problem when downloading the poll results as CSV. It requires to add the xblock-poll to the INSTALLED_APPS in django, For this purpose we use the variable ADDL_INSTALLED_APPS in Ansible.

The idea for upstream is to create PR where we add the xblock-poll to the OPTIONAL_APPS by default (common.py), and add the new version to the requirements files. This upstream pr is still pending.

I was wondering if it's better to overwrite the xblock-poll version through Ansible using the extra-requirements variable (it makes this PR unnecessary). What do you think?

@anmrdz 
@morenol 
@cocococosti 