### PR TITLE
Add support to absolute http/https urls.

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 <%def name='url(file, raw=False)'><%
 try:
+    if file.startswith("http"):
+        return file
     url = staticfiles_storage.url(file)
 except:
     url = file

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -404,6 +404,8 @@ def _absolute_url_staticfile(is_secure, name):
         unicode
 
     """
+    if name.startswith("https://") or name.startswith("http://"):
+        return name
     url_path = staticfiles_storage.url(name)
 
     # In production, the static files URL will be an absolute


### PR DESCRIPTION
This PR adds support to logo routes that starts with http or https in the url.

**TEST**

- In a site configuration/microsite add these settings:

```
"FOOTER_ORGANIZATION_IMAGE": "<Path_to_http/https_logo_url>",
"logo_image_url": "<Path_to_http/https_logo_url>",

```
- Check the logo changes on the tenant.