### PR TITLE
Updating Edunext dependencies

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -57,5 +57,5 @@ git+https://github.com/proversity-org/badgr-xblock.git@7077d499b2f752c78bb41e9c1
 # eduNEXT plugins #
 ###################
 # plugins must be editable for the settings to appear on the sys path during loading
--e git+https://github.com/eduNEXT/eox-tenant.git@v0.6.1#egg=eox-tenant==0.6.1
-git+https://github.com/eduNEXT/eox-core.git@v1.3.0#egg=eox-core==1.3.0
+-e git+https://github.com/eduNEXT/eox-tenant.git@v1.2.8#egg=eox-tenant==1.2.8
+git+https://github.com/eduNEXT/eox-core.git@v2.4.1#egg=eox-core==2.4.1


### PR DESCRIPTION
This PR adds the ednx plugins to the custom dependencies file. **This will break the tests but the reason for the tests failure is already identified. This will be fixed soon**

@morenol 
@felipemontoya 
@cocococosti 