### PR TITLE
Applying patch to enable password change from django admin

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -208,8 +208,9 @@ if settings.FEATURES.get('AUTH_USE_CAS'):
     ]
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
+if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+    urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/password_change/$', handler404))
-urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/', include(admin.site.urls)))
 
 # enable entrance exams

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -1,6 +1,7 @@
 """ Django admin pages for student app """
 from config_models.admin import ConfigurationModelAdmin
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 from django.contrib.auth import get_user_model
@@ -278,13 +279,17 @@ class UserChangeForm(BaseUserChangeForm):
     Override the default UserChangeForm such that the password field
     does not contain a link to a 'change password' form.
     """
-    password = ReadOnlyPasswordHashField(
-        label=_("Password"),
-        help_text=_(
-            "Raw passwords are not stored, so there is no way to see this "
-            "user's password."
-        ),
-    )
+    def __init__(self, *args, **kwargs):
+        super(UserChangeForm, self).__init__(*args, **kwargs)
+
+        if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+            self.fields["password"] = ReadOnlyPasswordHashField(
+                label=_("Password"),
+                help_text=_(
+                    "Raw passwords are not stored, so there is no way to see this "
+                    "user's password."
+                ),
+            )
 
 
 class UserAdmin(BaseUserAdmin):

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -785,11 +785,17 @@ if settings.FEATURES.get('CLASS_DASHBOARD'):
 
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     # Jasmine and admin
+
+    # The password pages in the admin tool are disabled so that all password
+    # changes go through our user portal and follow complexity requirements.
+    # The form to change another user's password is conditionally enabled
+    # for backwards compatibility.
+    if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+        urlpatterns += [
+            url(r'^admin/auth/user/\d+/password/$', handler404),
+        ]
     urlpatterns += [
-        # The password pages in the admin tool are disabled so that all password
-        # changes go through our user portal and follow complexity requirements.
         url(r'^admin/password_change/$', handler404),
-        url(r'^admin/auth/user/\d+/password/$', handler404),
         url(r'^admin/', include(admin.site.urls)),
     ]
 


### PR DESCRIPTION
This PR applies a patch (from https://github.com/edx/edx-platform/pull/21616) to enable user password change from the django admin page with a feature setting.

Tested in dev and works OK.