### PR TITLE
Bump eox-core version 2.4.2 to 2.4.3

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -58,4 +58,4 @@ git+https://github.com/proversity-org/badgr-xblock.git@7077d499b2f752c78bb41e9c1
 ###################
 # plugins must be editable for the settings to appear on the sys path during loading
 -e git+https://github.com/eduNEXT/eox-tenant.git@v1.2.10#egg=eox-tenant==1.2.10
-git+https://github.com/eduNEXT/eox-core.git@v2.4.2#egg=eox-core==2.4.2
+git+https://github.com/eduNEXT/eox-core.git@v2.4.3#egg=eox-core==2.4.3


### PR DESCRIPTION
###  Bump eox-core version 2.4.2 to 2.4.3

### **Description**

This PR bumps eox-core version from 2.4.2 to 2.4.3.