### PR TITLE
Applying patch plus extra fixes to unicode strings

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -152,10 +152,10 @@ class CohortTarget(Target):
         return self.short_display()
 
     def short_display(self):
-        return "{}-{}".format(self.target_type, self.cohort.name)
+        return u"{}-{}".format(self.target_type, self.cohort.name).encode('utf8')
 
     def long_display(self):
-        return "Cohort: {}".format(self.cohort.name)
+        return u"Cohort: {}".format(self.cohort.name).encode('utf8')
 
     @classmethod
     def ensure_valid_cohort(cls, cohort_name, course_id):
@@ -170,10 +170,10 @@ class CohortTarget(Target):
             cohort = get_cohort_by_name(name=cohort_name, course_key=course_id)
         except CourseUserGroup.DoesNotExist:
             raise ValueError(
-                "Cohort {cohort} does not exist in course {course_id}".format(
+                u"Cohort {cohort} does not exist in course {course_id}".format(
                     cohort=cohort_name,
                     course_id=course_id
-                )
+                ).encode('utf8')
             )
         return cohort
 


### PR DESCRIPTION
Applying patch from https://github.com/edx/edx-platform/commit/6e81c84d8bdef9b1eb70683a805ea20e6120b854 plus extra fixes to cohort strings:

When the cohort name has a unicode character, for example "promoción", the "Show email sent history" functionality at the instructor dashboard (lms) gives the following error:

` exceptions:UnicodeEncodeError: 'ascii' codec can't encode character u'\xf3' in position 28: ordinal not in range(128) `

The email history contains strings with the cohort name that were not unicode scaped. 

To solve this I scaped all strings with the cohort name, the others strings had the course ID and email which won't contain any special character.

![Selection_006](https://user-images.githubusercontent.com/24628951/68042647-c79ae300-fca9-11e9-9e66-a648f2332c63.png)

Tested in dev and works ok.

This solves ticket 7850.