### PR TITLE
Fix invocation of (edx.)HtmlUtils.ensureHtml

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -114,7 +114,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
             removeClass('is-disabled').
             attr('aria-disabled', false).
             prop('disabled', false).
-            html(HtmlUtils.ensureHtml(content).toString());
+            html(edx.HtmlUtils.ensureHtml(content).toString());
       }
       else {
         $submitButton.


### PR DESCRIPTION
Without this the following JS error occurs:

    Uncaught ReferenceError: HtmlUtils is not defined
        at toggleSubmitButton (login:658)

(cherry picked from commit 12cf50b0a96ae2b63ad4c1fe12d1b8bd2a889ff5)