### PR TITLE
Fixing prerequisites on courses

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -342,9 +342,14 @@ class GeneratedCertificate(models.Model):
         signal iff we are saving a record of a learner passing the course.
         As well as the COURSE_CERT_CHANGED for any save event.
         """
-        super(GeneratedCertificate, self).save(*args, **kwargs)
+        if GeneratedCertificate.__base__.__name__ == 'GeneratedCertificate':
+            super(GeneratedCertificate.__base__, self).save(*args, **kwargs)
+            sending_class = GeneratedCertificate.__base__
+        else:
+            super(GeneratedCertificate, self).save(*args, **kwargs)
+            sending_class = GeneratedCertificate
         COURSE_CERT_CHANGED.send_robust(
-            sender=self.__class__,
+            sender=sending_class,
             user=self.user,
             course_key=self.course_id,
             mode=self.mode,
@@ -352,7 +357,7 @@ class GeneratedCertificate(models.Model):
         )
         if CertificateStatuses.is_passing_status(self.status):
             COURSE_CERT_AWARDED.send_robust(
-                sender=self.__class__,
+                sender=sending_class,
                 user=self.user,
                 course_key=self.course_id,
                 mode=self.mode,


### PR DESCRIPTION
This PR makes the signals on the CertificateGenerated.save work with or without proxy.

This change can be evaluated during the upgrate to juniper and python3 maybe it is not necessary then.