### PR TITLE
Dont install local.in packages since they are already in the main req…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           name: Install local pip packages
           command: |
             source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.in
+            pip install -r requirements/edx/testing.txt
 
       - run:
           name: Run tests
@@ -150,7 +150,7 @@ jobs:
           name: Install local pip packages
           command: |
             source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.in
+            pip install -r requirements/edx/testing.txt
 
       - run:
           name: Run tests
@@ -187,7 +187,7 @@ jobs:
           name: Install local pip packages
           command: |
             source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.in
+            pip install -r requirements/edx/testing.txt
 
       - run:
           name: Run tests
@@ -224,7 +224,7 @@ jobs:
           name: Install local pip packages
           command: |
             source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.in
+            pip install -r requirements/edx/testing.txt
 
       - run:
           name: Run tests
@@ -262,7 +262,7 @@ jobs:
           name: Install local pip packages
           command: |
             source /tmp/workspace/venv/bin/activate
-            pip install -r requirements/edx/local.in
+            pip install -r requirements/edx/testing.txt
 
       - run:
           name: Run tests


### PR DESCRIPTION
This changes the circle ci config to install from testing.txt and not from local.in.

local.in does not include the version number of some packages used in the platform. testing.txt does and also includes all the requirements defined in local.in