### PR TITLE
ju/ednx/GI-10: Add support for metadata files that have more than one key

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -172,6 +172,16 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"),
+        "[@use='signing']",
+        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate",
+    ))
+
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
This PR modifies the process that fetches the SAML metadata to store the signing key when there is one specified explicitly.

Here the [Feature Document](https://docs.google.com/document/d/1iotYv0VKXGaSfEjxf_GlLFdWL2eGiag5kCB-Ff_TE6U)

**Tests:**

Followed the instructions left in the Feature Document

Additionally, I had to change [this](https://github.com/eduNEXT/edunext-platform/blob/06227ef6295c560ddd9a8fdfc359637fd6b63cfb/common/djangoapps/third_party_auth/tasks.py#L84) to `verify=False` so I could pass this error:

`requests.exceptions.SSLError: HTTPSConnectionPool(host='HOST', port=PORT): Max retries exceeded with url: /federationmetadata/2007-06/federationmetadata.xml (Caused by SSLError(SSLError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)'),))`

I changed it only for testing. Do you know anything about that? 

**Tests results:**

The local fetched is equal to the signing key at /federationmetadata/2007-06/federationmetadata.xml specified in the document