### PR TITLE
ju/ednx/LC-V2: Ednxsite awareness for language selection

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -84,9 +84,10 @@ class DarkLangMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """
-        Prevent user from requesting un-released languages except by using the preview-lang query string.
+        eduNEXT: this middleware will always process the requests.
+        The model has been modified to not even attempt the db lookup
         """
-        if not DarkLangConfig.current().enabled:
+        if not settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False) and not DarkLangConfig.current().enabled:
             return
 
         self._clean_accept_headers(request)
@@ -117,8 +118,13 @@ class DarkLangMiddleware(MiddlewareMixin):
         Remove any language that is not either in ``self.released_langs`` or
         a territory of one of those languages.
         """
+        ednx_locale = settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False)
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', None)
         if accept is None or accept == '*':
+            if ednx_locale:
+                # eduNEXT: return the site aware settings.LANGUAGE_CODE
+                # so that django.utils.locale.LocaleMiddleware can pick it up
+                request.META['HTTP_ACCEPT_LANGUAGE'] = "{};q={}".format(settings.LANGUAGE_CODE, "0.1")
             return
 
         new_accept = []
@@ -127,6 +133,9 @@ class DarkLangMiddleware(MiddlewareMixin):
             if fuzzy_code:
                 # Formats lang and priority into a valid accept header fragment.
                 new_accept.append("{};q={}".format(fuzzy_code, priority))
+            elif ednx_locale:
+                # eduNEXT: if there is no match, we set it to the settings.LANGUAGE_CODE
+                new_accept.append("{};q={}".format(settings.LANGUAGE_CODE, "0.1"))
 
         new_accept = ", ".join(new_accept)
 

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -4,6 +4,7 @@ Models for the dark-launching languages
 
 
 from config_models.models import ConfigurationModel
+from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -37,13 +38,20 @@ class DarkLangConfig(ConfigurationModel):
         ``released_languages`` as a list of language codes.
 
         Example: ['it', 'de-at', 'es', 'pt-br']
-        """
-        if not self.released_languages.strip():
-            return []
 
-        languages = [lang.lower().strip() for lang in self.released_languages.split(',')]
+        eduNEXT: we support only the list of available languages from the site
+        otherwise is the same as having no configuration
+        """
+        released_languages = self.released_languages
+
+        if settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
+            site_released_langs = getattr(settings, "released_languages", None)
+            released_languages = site_released_langs if site_released_langs else ""
+
+        languages = [lang.lower().strip() for lang in released_languages.split(',')]
         # Put in alphabetical order
         languages.sort()
+
         return languages
 
     @property


### PR DESCRIPTION
**Description**

This feature does a match between the languages that the user accepts -on their browser- and the languages available on this tenant. Ednxsite awareness for language selection. It replaces the regular DarkLang app with a ednxsite aware configuration.

**Tests**

Following the Feature Document, added LANGUAGE_CODE and released_languages to a test microsite:

```
"LANGUAGE_CODE":"en",
"released_languages":"en,ru,fr,es-419,de-DE,pt-BR"
```

**Tests results**

LMS:

![Screenshot from 2020-09-25 10-59-39](https://user-images.githubusercontent.com/64440265/94282892-5ea20680-ff1e-11ea-87e9-5b0b898ce71b.png)

STUDIO:

![Screenshot from 2020-09-25 11-10-17](https://user-images.githubusercontent.com/64440265/94284279-23083c00-ff20-11ea-9b53-324609e27749.png)

**Can we remove this feature of the platform?**

-After talking with @andrey-canon  -
 
I thought about moving this feature to eox-tenant or another plugging where it could make sense, it would be something like:

* Inherit from `DarkLangMiddleware` and override process_request as is done in this PR. Then, place this new middleware in the same spot as DarkLangMiddleware
* Make a proxy model using `DarkLangConfig` and override `released_languages_list` as is done in this PR

I wanted to start a discussion about if this change is worth it or not before trying it.


