### PR TITLE
ju/ednx/IR-5 Fix to prevent 500 error

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -767,7 +767,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        try:
+            return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        except ValueError:
+            return 0
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):


### PR DESCRIPTION
## Description
The problem arises when the tenant has defined PAID_COURSE_REGISTRATION_CURRENCY with a different currency than the currency defined in the course mode.