### PR TITLE
URL enconding the username in the path for the submission history URL

### DIFF
--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -25,7 +25,7 @@ function setup_debug(element_id, edit_link, staff_context){
             var location = $("#" + element_id + "_history_location").val();
 
             $("#" + element_id + "_history_text").load('/courses/' + "${unicode(course.id) | u}" +
-                "/submission_history/" + username + "/" + location);
+                "/submission_history/" + encodeURIComponent(username) + "/" + location);
             return false;
         }
     );


### PR DESCRIPTION
This PR solves an issue when using the "Submission history" functionality in the LMS (from a staff account).

When the username had spaces in it, the submission history wouldn't load, generating the following error:

![Screenshot from 2020-10-05 10-05-41](https://user-images.githubusercontent.com/24628951/95099793-5c019700-06fe-11eb-9a97-9e4da71c8a01.png)

This error was caused because the username in the url was passed as clear text without encoding it first.

After the fix:

![Screenshot from 2020-10-05 11-22-53](https://user-images.githubusercontent.com/24628951/95099914-83f0fa80-06fe-11eb-808f-9509ba4304ca.png)


Thanks to @spokerman12 for spotting the error https://3.basecamp.com/3966315/buckets/15592185/todos/2960032490/
