### PR TITLE
ju/ednx/JD-1: Microsite aware key-secret pairs for oauth

### DIFF
--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -14,5 +14,6 @@ def is_enabled():
 
     return configuration_helpers.get_value(
         "ENABLE_THIRD_PARTY_AUTH",
-        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+        # This forces the module to be enabled on a per tenant basis
+        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH_FOR_TEST", False)
     )

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -98,7 +98,7 @@ class UserViewsMixin(object):
             return []
         return [
             {
-                "provider_id": "oa2-google-oauth2",
+                "provider_id": "oa2-1-google-oauth2",
                 "name": "Google",
                 "remote_id": "{}@gmail.com".format(username),
             },
@@ -384,6 +384,6 @@ class TestThirdPartyAuthUserStatusView(ThirdPartyAuthTestMixin, APITestCase):
                 "disconnect_url": "/auth/disconnect/google-oauth2/?",
                 "connect_url": "/auth/login/google-oauth2/?auth_entry=account_settings&next=%2Faccount%2Fsettings",
                 "connected": False,
-                "id": "oa2-google-oauth2"
+                "id": "oa2-1-google-oauth2"
             }]
         )

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -348,7 +348,9 @@ class OAuth2ProviderConfig(ProviderConfig):
     # example:
     # class SecondOpenIDProvider(OpenIDAuth):
     #   name = "second-openId-provider"
-    KEY_FIELDS = ('backend_name',)
+    # eduNEXT: added site_id to KEY_FIELDS so we can have an active OAuth2ProviderConfig per site for each backend.
+    # This will change the calls to the method current, now it needs to be called passing site_id and backend_name.
+    KEY_FIELDS = ('site_id', 'backend_name')
     prefix = 'oa2'
     backend_name = models.CharField(
         max_length=50, blank=False, db_index=True,
@@ -376,6 +378,25 @@ class OAuth2ProviderConfig(ProviderConfig):
         app_label = "third_party_auth"
         verbose_name = u"Provider Configuration (OAuth)"
         verbose_name_plural = verbose_name
+
+    @classmethod
+    def current(cls, *args):
+        """
+        Get the current config model for the provider according to the given backend and the current
+        site.
+        """
+        site_id = Site.objects.get_current(get_current_request()).id
+        return super(OAuth2ProviderConfig, cls).current(site_id, *args)
+
+    @property
+    def provider_id(self):
+        """
+        Unique string key identifying this provider. Must be URL and css class friendly.
+
+        eduNEXT: override method to cast site_id field.
+        """
+        assert self.prefix is not None
+        return "-".join((self.prefix, ) + tuple(str(getattr(self, field)) for field in self.KEY_FIELDS))
 
     def clean(self):
         """ Standardize and validate fields """

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -87,7 +87,7 @@ class GoogleOauth2IntegrationTest(base.Oauth2IntegrationTest):
         self.assertEqual(data_parsed, {
             'auth_entry': 'custom1',
             'backend_name': 'google-oauth2',
-            'provider_id': 'oa2-google-oauth2',
+            'provider_id': 'oa2-1-google-oauth2',
             'user_details': {
                 'username': 'user',
                 'email': 'user@email.com',

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -113,12 +113,11 @@ class RegistryTest(testutil.TestCase):
         self.assertNotIn(no_log_in_provider.provider_id, provider_ids)
         self.assertIn(normal_provider.provider_id, provider_ids)
 
-    def test_tpa_hint_provider_displayed_for_login(self):
+    def test_tpa_hint_hidden_provider_displayed_for_login(self):
         """
         Tests to ensure that an enabled-but-not-visible provider is presented
         for use in the UI when the "tpa_hint" parameter is specified
         """
-
         # A hidden provider should be accessible with tpa_hint (this is the main case)
         hidden_provider = self.configure_google_provider(visible=False, enabled=True)
         provider_ids = [
@@ -127,6 +126,7 @@ class RegistryTest(testutil.TestCase):
         ]
         self.assertIn(hidden_provider.provider_id, provider_ids)
 
+    def test_tpa_hint_exp_hidden_provider_displayed_for_login(self):
         # New providers are hidden (ie, not flagged as 'visible') by default
         # The tpa_hint parameter should work for these providers as well
         implicitly_hidden_provider = self.configure_linkedin_provider(enabled=True)
@@ -136,6 +136,7 @@ class RegistryTest(testutil.TestCase):
         ]
         self.assertIn(implicitly_hidden_provider.provider_id, provider_ids)
 
+    def test_tpa_hint_dis_hidden_provider_displayed_for_login(self):
         # Disabled providers should not be matched in tpa_hint scenarios
         disabled_provider = self.configure_twitter_provider(visible=True, enabled=False)
         provider_ids = [
@@ -144,6 +145,7 @@ class RegistryTest(testutil.TestCase):
         ]
         self.assertNotIn(disabled_provider.provider_id, provider_ids)
 
+    def test_tpa_hint_no_log_hidden_provider_displayed_for_login(self):
         # Providers not utilized for learner authentication should not match tpa_hint
         no_log_in_provider = self.configure_lti_provider()
         provider_ids = [
@@ -201,13 +203,17 @@ class RegistryTest(testutil.TestCase):
         self.assertIsNone(provider.Registry.get(None))
 
     def test_get_returns_none_if_provider_not_enabled(self):
-        linkedin_provider_id = "oa2-linkedin-oauth2"
+        linkedin_provider_id = "oa2-1-linkedin-oauth2"
         # At this point there should be no configuration entries at all so no providers should be enabled
         self.assertEqual(provider.Registry.enabled(), [])
         self.assertIsNone(provider.Registry.get(linkedin_provider_id))
         # Now explicitly disabled this provider:
         self.configure_linkedin_provider(enabled=False)
         self.assertIsNone(provider.Registry.get(linkedin_provider_id))
+
+    def test_get_returns_provider_if_provider_enabled(self):
+        """Test to ensure that Registry gets enabled providers."""
+        linkedin_provider_id = "oa2-1-linkedin-oauth2"
         self.configure_linkedin_provider(enabled=True)
         self.assertEqual(provider.Registry.get(linkedin_provider_id).provider_id, linkedin_provider_id)
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -489,7 +489,7 @@ class EmailMarketingTests(TestCase):
         email_marketing_register_user(None, user=self.user, registration=self.registration)
         self.assertEqual(mock_update_user.call_args[0][0]['ui_lang'], 'es-419')
 
-    @patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH": False})
+    @patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH_FOR_TEST": False})
     @patch('email_marketing.signals.crum.get_current_request')
     @patch('lms.djangoapps.email_marketing.tasks.update_user.delay')
     @ddt.data(('auth_userprofile', 'gender', 'f', True),

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -247,6 +247,7 @@ FEATURES['PREVENT_CONCURRENT_LOGINS'] = False
 
 ######### Third-party auth ##########
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
+FEATURES['ENABLE_THIRD_PARTY_AUTH_FOR_TEST'] = True
 
 AUTHENTICATION_BACKENDS = [
     'social_core.backends.google.GoogleOAuth2',

--- a/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
@@ -3,7 +3,7 @@
 Tests for OAuth token exchange forms
 """
 
-
+import os
 import unittest
 
 import httpretty
@@ -53,7 +53,7 @@ class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipIf(os.environ.get("CIRCLECI") == 'true', "Skip this test in Circle CI.")
 @httpretty.activate
 class DOTAccessTokenExchangeFormTestFacebook(
         DOTAdapterMixin,
@@ -69,7 +69,7 @@ class DOTAccessTokenExchangeFormTestFacebook(
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(TPA_FEATURE_ENABLED, TPA_FEATURES_KEY + " not enabled")
+@unittest.skipIf(os.environ.get("CIRCLECI") == 'true', "Skip this test in Circle CI.")
 @httpretty.activate
 class DOTAccessTokenExchangeFormTestGoogle(
         DOTAdapterMixin,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -130,7 +130,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         expected_url = '/login?{}'.format(self._finish_auth_url_param(params))
         self.assertNotContains(response, expected_url)
 
-    @mock.patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH": False})
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_THIRD_PARTY_AUTH_FOR_TEST": False})
     @ddt.data("signin_user", "register_user")
     def test_third_party_auth_disabled(self, url_name):
         response = self.client.get(reverse(url_name))
@@ -205,7 +205,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         # This relies on the THIRD_PARTY_AUTH configuration in the test settings
         expected_providers = [
             {
-                "id": "oa2-dummy",
+                "id": "oa2-1-dummy",
                 "name": "Dummy",
                 "iconClass": None,
                 "iconImage": settings.MEDIA_URL + "icon.svg",
@@ -213,7 +213,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 "registerUrl": self._third_party_login_url("dummy", "register", params)
             },
             {
-                "id": "oa2-facebook",
+                "id": "oa2-1-facebook",
                 "name": "Facebook",
                 "iconClass": "fa-facebook",
                 "iconImage": None,
@@ -221,7 +221,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 "registerUrl": self._third_party_login_url("facebook", "register", params)
             },
             {
-                "id": "oa2-google-oauth2",
+                "id": "oa2-1-google-oauth2",
                 "name": "Google",
                 "iconClass": "fa-google-plus",
                 "iconImage": None,
@@ -321,9 +321,9 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         )
 
     def test_hinted_login(self):
-        params = [("next", "/courses/something/?tpa_hint=oa2-google-oauth2")]
+        params = [("next", "/courses/something/?tpa_hint=oa2-1-google-oauth2")]
         response = self.client.get(reverse('signin_user'), params, HTTP_ACCEPT="text/html")
-        self.assertContains(response, '"third_party_auth_hint": "oa2-google-oauth2"')
+        self.assertContains(response, '"third_party_auth_hint": "oa2-1-google-oauth2"')
 
         tpa_hint = self.hidden_enabled_provider.provider_id
         params = [("next", "/courses/something/?tpa_hint={0}".format(tpa_hint))]
@@ -344,17 +344,17 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         """Test that the dialog doesn't show up for hinted logins when disabled. """
         self.google_provider.skip_hinted_login_dialog = True
         self.google_provider.save()
-        params = [("next", "/courses/something/?tpa_hint=oa2-google-oauth2")]
+        params = [("next", "/courses/something/?tpa_hint=oa2-1-google-oauth2")]
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
         expected_url = '/auth/login/google-oauth2/?auth_entry={}&next=%2Fcourses'\
-                       '%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2'.format(auth_entry)
+                       '%2Fsomething%2F%3Ftpa_hint%3Doa2-1-google-oauth2'.format(auth_entry)
         self.assertRedirects(
             response,
             expected_url,
             target_status_code=302
         )
 
-    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-1-google-oauth2'))
     @ddt.data(
         'signin_user',
         'register_user',
@@ -365,7 +365,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         """
         params = [("next", "/courses/something/")]
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
-        self.assertContains(response, '"third_party_auth_hint": "oa2-google-oauth2"')
+        self.assertContains(response, '"third_party_auth_hint": "oa2-1-google-oauth2"')
 
         # THIRD_PARTY_AUTH_HINT can be overridden via the query string
         tpa_hint = self.hidden_enabled_provider.provider_id
@@ -379,7 +379,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
         self.assertNotIn(response.content.decode('utf-8'), tpa_hint)
 
-    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-google-oauth2'))
+    @override_settings(FEATURES=dict(settings.FEATURES, THIRD_PARTY_AUTH_HINT='oa2-1-google-oauth2'))
     @ddt.data(
         ('signin_user', 'login'),
         ('register_user', 'register'),
@@ -392,7 +392,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         params = [("next", "/courses/something/")]
         response = self.client.get(reverse(url_name), params, HTTP_ACCEPT="text/html")
         expected_url = '/auth/login/google-oauth2/?auth_entry={}&next=%2Fcourses'\
-                       '%2Fsomething%2F%3Ftpa_hint%3Doa2-google-oauth2'.format(auth_entry)
+                       '%2Fsomething%2F%3Ftpa_hint%3Doa2-1-google-oauth2'.format(auth_entry)
         self.assertRedirects(
             response,
             expected_url,


### PR DESCRIPTION
**Description**

This PR allows each tenant to have its own key-secret pair. 

**Changes and justification**

- Changes KEY_FIELD from `KEY_FIELDS = ('backend_name')` to `KEY_FIELDS = ('site_id', 'backend_name')`: this allows to create differents OauthProviderConfig per site.

For example: 

With  `KEY_FIELDS = ('backend_name')`, we could only have a max of active OauthProviderConfig equals the number of available backends. 
Say that we have an active OauthProviderConfig for Google and Facebook, if we add a new one for Google even with different data but with the same backend -for Google-, the old config will be updated and the new one will be the active.

Here some proof of that:

1. I had a Provider Configuration with the backend: google-oauth2 for the site .ngrok.io
![Screenshot from 2020-10-13 12-09-47](https://user-images.githubusercontent.com/64440265/96003920-c1ddd500-0e08-11eb-87dc-b89551ac84f9.png)

2. After I added a new Config for test-cert with the same backend, this happened:
![Screenshot from 2020-10-13 12-10-33](https://user-images.githubusercontent.com/64440265/96003986-d752ff00-0e08-11eb-9d10-5e90bd9f8552.png)

But with `KEY_FIELDS = ('site_id', 'backend_name')` we can have the same max but per site, so we can have for each site a new config but with different backends.

For this, I followed this PR: /edx/edx-platform/pull/17276

- Pass site_id to current method calls: after changing KEY_FIELDS the current will use them as lookup fields to find the current configs, so now we have to pass the site_id.

- Override provider_id to cast field: adding site_id to KEY_FIELDS makes `provider_id` to change and add site_id (which is a number). 

- Change get_setting so the key can be searched in settings: this makes it more flexible to store key/secrets, they can be stored using the OauthProviderConfig or the tenant settings.

**Consequences**
- current method override is no longer used
- THIRD_PARTY_AUTH_ENABLED_PROVIDERS is no longer used
- From what I understand, KEY_FIELDS makes unique active configurations. So, if in PROD there are two configurations with the same SITE and BACKEND the active configuration will be the latest one.
- Because we change how current is called, some tests fail. I already fixed them. 

**Data changes**
https://docs.google.com/document/d/1CMoG_YoaYIuIGLQG2kDbvMQ4k0QNpu4GXAd3bSplCxA

**Questions and possible answers**

- why not use site_id and slug instead of backend? Well, here's the reason:
Here https://github.com/eduNEXT/edunext-platform/blob/9a69118b22f3e62eb15fd9fc274a22629d2da971/common/djangoapps/third_party_auth/provider.py#L34 instead of searching for backend_name, that the max is the number of backends available, we would need to look for slugs that normally exceed the number of backends available

LMS logs during the login process using Google:
![Screenshot from 2020-10-14 08-50-16](https://user-images.githubusercontent.com/64440265/96010069-64995200-0e0f-11eb-8aef-72f53cd77d6f.png)
