### PR TITLE
Jhony/performance problem csv report

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -412,6 +412,9 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             raise ValueError("Only Scope.user_state is supported")
 
         results = StudentModule.objects.order_by('id').filter(module_state_key=block_key)
+        course_key = getattr(block_key, 'course_key', None)
+        if course_key:
+            results = results.filter(course_id=course_key)
         p = Paginator(results, settings.USER_STATE_BATCH_SIZE)
 
         for page_number in p.page_range:

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -432,9 +432,12 @@ def list_problem_responses(course_key, problem_location, limit_responses=None):
     if problem_key.course_key != course_key:
         return []
 
-    smdat = StudentModule.objects.filter(
+    inner_ids = StudentModule.objects.filter(
         course_id=course_key,
         module_state_key=problem_key
+    ).values_list('pk', flat=True)
+    smdat = StudentModule.objects.filter(
+        id__in=list(inner_ids)
     )
     smdat = smdat.order_by('student')
     if limit_responses is not None:

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -102,7 +102,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
                 # Check if list_problem_responses called UsageKey.from_string to look up problem key:
                 patched_from_string.assert_called_once_with(mock_problem_location)
                 # Check if list_problem_responses called StudentModule.objects.filter to obtain relevant records:
-                patched_manager.filter.assert_called_once_with(
+                patched_manager.filter.assert_any_call(
                     course_id=self.course_key, module_state_key=mock_problem_key
                 )
 


### PR DESCRIPTION
This PR tries to solve an issue with instructor problem_responses_csv reports. In some cases, the report is taking too long to generate. The SRE team discovered that the bottleneck is the MySQL layer since queries to the Student Module table are not efficient. The PR affects 2 methods:

- iter_all_for_block: this method belongs to DjangoXBlockUserStateClient class, and it performs a query to the Student Module table using only a module_state_key as a query parameter. This field is not indexed in the table, generating long query times as this table contains a lot of records. The change to this method consists of using the **course_key** as an additional filter parameter which speeds up the queries. All student module records have non-null course_key values.  

- list_problem_responses: This method uses module_state_key and course_key to filter the Student Module table. The problem here is the ordering: it uses the student field of the table to order the results, which causes delays in some cases. To mitigate this issue, an extra query is performed: first, the ids of the Student Module records with the specified module_state_key and course_key are extracted, then that list is used as input in a new query to bring Student Module records with the corresponding ids. This makes sorting much faster.

Important to mention these methods are not called anywhere else. this solution was tested in a report that took 2 hours, now it takes 2 minutes maximum 

@felipemontoya 
@andrey-canon 