### PR TITLE
ju/ednx/JU-6: Hooks support

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -77,6 +77,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 from student.signals import ENROLL_STATUS_CHANGE, ENROLLMENT_TRACK_UPDATED, UNENROLL_DONE
+from openedx.core.lib.triggers.v1 import pre_enrollment, TriggerException
 from track import contexts, segment
 from util.milestones_helpers import is_entrance_exams_enabled
 from util.model_utils import emit_field_changed_events, get_changed_fields_dict
@@ -1442,7 +1443,23 @@ class CourseEnrollment(models.Model):
         verified the user authentication.
 
         Also emits relevant events for analytics purposes.
+
+        This method triggers a public signal that may prevent the creation of the enrollment.
         """
+
+        # This signal allows plugins to extend the behaviour of the enrollment process.
+        try:
+            hook_result = pre_enrollment.send(sender=None, user=user, course_key=course_key, mode=mode)
+        except Exception as error:
+            raise TriggerException(error.message)  # pylint: disable=no-member
+
+        for receiver_func, func_response in hook_result:
+            log.info(
+                u"This is the result of calling the pre_enrollment signal. Receiver was %s and response %s",
+                receiver_func,
+                func_response,
+            )
+
         if mode is None:
             mode = _default_course_mode(text_type(course_key))
         # All the server-side checks for whether a user is allowed to enroll.

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -53,6 +53,7 @@ from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangolib.markup import HTML, Text
 from student.helpers import DISABLE_UNENROLL_CERT_STATES, cert_info, generate_activation_email_context
 from student.message_types import AccountActivation, EmailChange, EmailChangeConfirmation, RecoveryEmailCreate
+from openedx.core.lib.triggers.v1 import TriggerException
 from student.models import (
     AccountRecovery,
     CourseEnrollment,
@@ -360,6 +361,8 @@ def change_enrollment(request, check_access=True):
                 enroll_mode = CourseMode.auto_enroll_mode(course_id, available_modes)
                 if enroll_mode:
                     CourseEnrollment.enroll(user, course_id, check_access=check_access, mode=enroll_mode)
+            except TriggerException as error:
+                return HttpResponseBadRequest(error.message)  # pylint: disable=no-member
             except Exception:  # pylint: disable=broad-except
                 return HttpResponseBadRequest(_("Could not enroll"))
 

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -24,6 +24,7 @@ from openedx.core.djangoapps.enrollments.api import add_enrollment
 from openedx.core.djangoapps.enrollments.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.core.lib.triggers.v1 import TriggerException
 from student.models import CourseEnrollment
 from student.signals import SAILTHRU_AUDIT_PURCHASE
 from util.json_request import JsonResponse
@@ -153,7 +154,10 @@ class BasketsView(APIView):
                     announcement=course_announcement
                 )
             log.info(msg)
-            self._enroll(course_key, user, default_enrollment_mode.slug)
+            try:
+                self._enroll(course_key, user, default_enrollment_mode.slug)
+            except TriggerException as error:
+                return DetailResponse(error.message, status=HTTP_406_NOT_ACCEPTABLE)
             mode = CourseMode.AUDIT if audit_mode else CourseMode.HONOR
             SAILTHRU_AUDIT_PURCHASE.send(
                 sender=None, user=user, mode=mode, course_id=course_id

--- a/openedx/core/lib/triggers/v1.py
+++ b/openedx/core/lib/triggers/v1.py
@@ -1,0 +1,19 @@
+"""
+This module defines the signals supported for public consumption.
+
+This definition is still experimental.
+See: https://docs.google.com/document/d/1jhnudz6AVtVt0ZSRSwOwj9gJ0lsDDn_8mUCPehLPzLw/edit.
+"""
+import django.dispatch
+
+
+class TriggerException(Exception):
+    """Raised when the sending of the signal of a trigger fails"""
+
+
+# This definition is the first POC used in production for adding additional business rules to the enrollment
+pre_enrollment = django.dispatch.Signal(providing_args=[
+    "user",
+    "course_key",
+    "mode",
+])


### PR DESCRIPTION
**Description:**

Adds support to the first implementation of the [Hooks](https://drive.google.com/a/edunext.co/open?id=1iep7Hcac7oylmpLHqnPnvOeywCqyiIRLhPIssHMNpwQ) concept in Juniper. 

The implementation consists of the pre_enrollment hook, that if enabled, sends a signal that executes a pre-defined action.

**Tests:**

- [x] preenrollment_hook:  test that the signal sent during the enrollment process triggers an action. In this test, the action used was the one defined in eox-taylor.

