### PR TITLE
ju/ednx/JU-1: Show error messages as unicode strings

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -183,10 +183,10 @@ class CohortTarget(Target):
             cohort = get_cohort_by_name(name=cohort_name, course_key=course_id)
         except CourseUserGroup.DoesNotExist:
             raise ValueError(
-                u"Cohort {cohort} does not exist in course {course_id}".format(
+                "Cohort {cohort} does not exist in course {course_id}".format(
                     cohort=cohort_name,
                     course_id=course_id
-                ).encode('utf8')
+                )
             )
         return cohort
 
@@ -232,10 +232,10 @@ class CourseModeTarget(Target):
             validate_course_mode(six.text_type(course_id), mode_slug, include_expired=True)
         except CourseModeNotFoundError:
             raise ValueError(
-                u"Track {track} does not exist in course {course_id}".format(
+                "Track {track} does not exist in course {course_id}".format(
                     track=mode_slug,
                     course_id=course_id
-                ).encode('utf8')
+                )
             )
 
 
@@ -276,8 +276,8 @@ class CourseEmail(Email):
             target_split = target.split(':', 1)
             # Ensure our desired target exists
             if target_split[0] not in EMAIL_TARGETS:
-                fmt = u'Course email being sent to unrecognized target: "{target}" for "{course}", subject "{subject}"'
-                msg = fmt.format(target=target, course=course_id, subject=subject).encode('utf8')
+                fmt = 'Course email being sent to unrecognized target: "{target}" for "{course}", subject "{subject}"'
+                msg = fmt.format(target=target, course=course_id, subject=subject)
                 raise ValueError(msg)
             elif target_split[0] == SEND_TO_COHORT:
                 # target_split[1] will contain the cohort name


### PR DESCRIPTION
This PR is related to  #346 
Encoding all of the strings with the cohort name will no longer be necessary since for python 3+
strings are by default Unicode strings. When the cohort name has a unicode character, the "Show email sent history" functionality at the instructor dashboard (lms) works properly.

The encode method getting called in some of the error messages encodes the Unicode string into bytes, 
for cases where there are special characters, the message is not being shown properly.
`  File "/edx/app/edxapp/edx-platform/lms/djangoapps/bulk_email/models.py", line 296, in create
    raise ValueError(msg)
ValueError:b'Course email being sent to unrecognized target: "email-test@example.com:test" for "course-v1:edX+DemoX+Demo_Course", subject "Pr\xc3\xbaeba c\xc3\xb3n ac\xc3\xa9nt\xc3\xb3"'
`

To solve this I removed the u at the beginning of the strings and the encode utf-8 method.
`  File "/edx/app/edxapp/edx-platform/lms/djangoapps/bulk_email/models.py", line 296, in create
    raise ValueError(msg)
ValueError: Course email being sent to unrecognized target: "email-test@example.com:test" for "course-v1:edX+DemoX+Demo_Course", subject "Prúeba cón acéntó"
`