### PR TITLE
ju/ednx/JU-9: Fix performance problem with csv report

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -414,6 +414,9 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             raise ValueError("Only Scope.user_state is supported")
 
         results = StudentModule.objects.order_by('id').filter(module_state_key=block_key)
+        course_key = getattr(block_key, 'course_key', None)
+        if course_key:
+            results = results.filter(course_id=course_key)
         p = Paginator(results, settings.USER_STATE_BATCH_SIZE)
 
         for page_number in p.page_range:

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -459,9 +459,12 @@ def list_problem_responses(course_key, problem_location, limit_responses=None):
     if problem_key.course_key != course_key:
         return []
 
-    smdat = StudentModule.objects.filter(
+    inner_ids = StudentModule.objects.filter(
         course_id=course_key,
         module_state_key=problem_key
+    ).values_list('pk', flat=True)
+    smdat = StudentModule.objects.filter(
+        id__in=list(inner_ids),
     )
     smdat = smdat.order_by('student')
     if limit_responses is not None:

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -127,7 +127,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
                 # Check if list_problem_responses called UsageKey.from_string to look up problem key:
                 patched_from_string.assert_called_once_with(mock_problem_location)
                 # Check if list_problem_responses called StudentModule.objects.filter to obtain relevant records:
-                patched_manager.filter.assert_called_once_with(
+                patched_manager.filter.assert_any_call(
                     course_id=self.course_key, module_state_key=mock_problem_key
                 )
 


### PR DESCRIPTION
Fix taken from #435 

**Description**

This PR tries to solve an issue with instructor problem_responses_csv reports. In some cases, the report is taking too long to generate. The SRE team discovered that the bottleneck is the MySQL layer since queries to the Student Module table are not efficient. 

**Tests**

Tested in dev generating _Problem responses csv_:
![Screenshot from 2020-11-02 12-09-20](https://user-images.githubusercontent.com/64440265/97890759-5189eb80-1d04-11eb-9f0a-92fecd51393f.png)
