### PR TITLE
ju/ednx/JU-8: Fix submissions history

### DIFF
--- a/lms/templates/courseware/xqa_interface.html
+++ b/lms/templates/courseware/xqa_interface.html
@@ -29,7 +29,7 @@ function setup_debug(element_id, edit_link, staff_context){
             var location = $("#" + element_id + "_history_location").val();
             // xss-lint: disable=mako-invalid-js-filter
             $("#" + element_id + "_history_text").load('/courses/' + "${six.text_type(getattr(course,'id','')) | u}" +
-                "/submission_history/" + username + "/" + location);
+                "/submission_history/" + encodeURIComponent(username) + "/" + location);
             return false;
         }
     );


### PR DESCRIPTION
Fix taken from #431 

**Description**

This PR solves an issue when using the "Submission history" functionality in the LMS (from a staff account) with a username with spaces.

**Tests**

In a multiple-choice question, clicked _Submission history_ -using a staff account- and tested before and after the change.

Before:
![Screenshot from 2020-10-28 09-11-22](https://user-images.githubusercontent.com/64440265/97440568-ff108f80-18fd-11eb-91f6-316b607d16a3.png)

After:
![Screenshot from 2020-10-28 09-12-01](https://user-images.githubusercontent.com/64440265/97440592-059f0700-18fe-11eb-9775-445ac3452e90.png)
