### PR TITLE
ju/ednx/JU-7: Fix SGA issue with grading

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -261,12 +261,22 @@ def _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs):
         found_modified_time = score.modified if score is not None else None
 
     elif kwargs['score_db_table'] == ScoreDatabaseTableEnum.submissions:
+        # This block_type assignation is to address this issue with edx sga xblock:
+        # https://discuss.openedx.org/t/problems-with-sga-grade-submission/2415
+        # This should be removed as soon as we find a proper
+        # and maintainable solution.
+        block_type = (
+            scored_block_usage_key.block_type
+            if scored_block_usage_key.block_type != 'edx_sga'
+            else 'sga'
+        )
+
         score = sub_api.get_score(
             {
                 "student_id": kwargs['anonymous_user_id'],
                 "course_id": six.text_type(scored_block_usage_key.course_key),
                 "item_id": six.text_type(scored_block_usage_key),
-                "item_type": scored_block_usage_key.block_type,
+                "item_type": block_type,
             }
         )
         found_modified_time = score['created_at'] if score is not None else None


### PR DESCRIPTION
This PR is related to #408
This is a temporary solution while edx-sga does not make the necessary changes to solve this issue. Here is a complete explanation of the problem and its possible solutions [Problems with sga grade submission](https://discuss.openedx.org/t/problems-with-sga-grade-submission/2415).

Tested this in local. The DatabaseNotReadyError no longer appears and the subsection grades are updated successfully.