### PR TITLE
ju/ednx/JU-3: Fix CertificateGenerated.save proxy

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -401,7 +401,7 @@ class GeneratedCertificate(models.Model):
         signal iff we are saving a record of a learner passing the course.
         As well as the COURSE_CERT_CHANGED for any save event.
         """
-        super(GeneratedCertificate, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         COURSE_CERT_CHANGED.send_robust(
             sender=self.__class__,
             user=self.user,


### PR DESCRIPTION
PR related to https://github.com/eduNEXT/edunext-platform/pull/372 

**Description and justification**

This PR makes CertificateGenerated.save work with or without proxy.

Chaging _super_ from `super(GeneratedCertificate, self)` -python 2.7- to `super()` -python 3- ([reference](https://www.python.org/dev/peps/pep-3135/))   fixes the following error when using `TenantGeneratedCertificateProxy`:

```
super(GeneratedCertificate, self).save(*args, **kwargs)
TypeError: super(type, obj): obj must be an instance or subtype of type
```

This error was raised because `type` or GeneratedCertificate was  `<class 'eox_tenant.tenant_wise.proxies.TenantGeneratedCertificateProxy'>` instead of` <class 'lms.djangoapps.certificates.models.GeneratedCertificate'>`. 

After the super().save(*args, **kwargs) finishes,  the respective signals are sent with `sender=self.__class__ `(`or <class 'lms.djangoapps.certificates.models.GeneratedCertificate'>`)
 
**Tests**

Tested adding a new GeneratedCertificate using django-admin.

Before JU-3:
![Screenshot from 2020-11-02 12-59-07](https://user-images.githubusercontent.com/64440265/97896499-864d7100-1d0b-11eb-9c32-f25bd6b5479c.png)

After:
![Screenshot from 2020-11-02 12-59-56](https://user-images.githubusercontent.com/64440265/97896510-8b122500-1d0b-11eb-870d-c6ab702c940e.png)

and  `self.__class__ == <class 'lms.djangoapps.certificates.models.GeneratedCertificate'>`

The COURSE_CERT_CHANGED receivers -`handle_course_cert_changed` and `handle_cert_change`- were tested to check the correct signal functionality.
