### PR TITLE
ju/ednx/BC-19_P7: Fix lti-consumer versions and duplicates

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -19,19 +19,19 @@ cryptography==2.9.2       # via -c requirements/edunext/../edx/base.txt, social-
 cssselect==1.1.0          # via parsel
 defusedxml==0.6.0         # via -c requirements/edunext/../edx/base.txt, python3-openid, social-auth-core
 django-crum==0.7.6        # via -c requirements/edunext/../edx/base.txt, edx-proctoring
-django-filter==2.2.0      # via -c requirements/edunext/../edx/base.txt, eox-core, lti-consumer-xblock
+django-filter==2.2.0      # via -c requirements/edunext/../edx/base.txt, eox-core
 django-ipware==2.1.0      # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 django-model-utils==4.0.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring, edx-when
 django-oauth-toolkit==1.3.2  # via -c requirements/edunext/../edx/base.txt, eox-core
 django-waffle==0.18.0     # via -c requirements/edunext/../edx/base.txt, edx-django-utils, edx-drf-extensions, edx-proctoring, eox-core
 django-webpack-loader==0.7.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring
-django==2.2.16            # via -c requirements/edunext/../edx/base.txt, django-crum, django-filter, django-model-utils, django-oauth-toolkit, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, edx-when, eox-hooks, event-tracking, jsonfield2, lti-consumer-xblock, rest-condition, xblock-free-text-response
+django==2.2.16            # via -c requirements/edunext/../edx/base.txt, django-crum, django-filter, django-model-utils, django-oauth-toolkit, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, edx-when, eox-hooks, event-tracking, jsonfield2, rest-condition, xblock-free-text-response
 djangorestframework==3.9.4  # via -c requirements/edunext/../edx/base.txt, drf-jwt, edx-drf-extensions, edx-proctoring, eox-core, eox-hooks, rest-condition
 drf-jwt==1.14.0           # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions
 ecdsa==0.14.1             # via python-jose
 edx-django-utils==3.2.2   # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-rest-api-client, edx-when
 edx-drf-extensions==6.0.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring, edx-when
-edx-opaque-keys[django]==2.1.0  # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-proctoring, edx-when, eox-core, flow-control-xblock, lti-consumer-xblock
+edx-opaque-keys[django]==2.1.0  # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-proctoring, edx-when, eox-core, flow-control-xblock
 edx-proctoring==2.4.0     # via -c requirements/edunext/../edx/base.txt, eox-core
 edx-rest-api-client==5.2.1  # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 edx-when==1.2.3           # via -c requirements/edunext/../edx/base.txt, edx-proctoring
@@ -46,8 +46,7 @@ future==0.18.2            # via -c requirements/edunext/../edx/base.txt, pyjwkes
 idna==2.9                 # via -c requirements/edunext/../edx/base.txt, requests
 jsonfield2==3.0.3         # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 kombu==3.0.37             # via -c requirements/edunext/../edx/base.txt, celery
-lazy==1.4                 # via -c requirements/edunext/../edx/base.txt, lti-consumer-xblock
-git+https://github.com/eduNEXT/xblock-lti-consumer.git@v2.3.2#egg=xblock-lti-consumer==2.3.2  # via -r requirements/edunext/github.in
+git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=xblock-lti-consumer==v1.2.6.1  # via -r requirements/edunext/github.in
 lxml==4.5.0               # via -c requirements/edunext/../edx/base.txt, lti-consumer-xblock, parsel, xblock
 mako==1.0.2               # via -c requirements/edunext/../edx/base.txt, lti-consumer-xblock, schoolyourself-xblock, xblock-utils
 markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, mako, xblock
@@ -60,8 +59,8 @@ pbr==5.4.5                # via -c requirements/edunext/../edx/base.txt, stevedo
 psutil==1.2.1             # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via -c requirements/edunext/../edx/base.txt, cffi
-pycryptodomex==3.9.7      # via -c requirements/edunext/../edx/base.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
-pyjwkest==1.4.2           # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, lti-consumer-xblock
+pycryptodomex==3.9.7      # via -c requirements/edunext/../edx/base.txt, edx-proctoring, pyjwkest
+pyjwkest==1.4.2           # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions
 pyjwt==1.5.2              # via -c requirements/edunext/../edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pymongo==3.9.0            # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys, event-tracking
 pyparsing==2.4.7          # via -c requirements/edunext/../edx/base.txt, packaging

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -75,4 +75,4 @@ git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-f
 git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.0#egg=edx_xblock_scorm==1.0.0
 
 # Patched version that includes the fullname
-git+https://github.com/eduNEXT/xblock-lti-consumer.git@v2.3.2#egg=xblock-lti-consumer==2.3.2
+git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=xblock-lti-consumer==v1.2.6.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -148,10 +148,9 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6  # via -r requirements/edx/github.in
-lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
+lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
-mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, xblock-google-drive, xblock-utils
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via django-babel-underscore
 markupsafe==1.1.1         # via -r requirements/edx/paver.txt, chem, jinja2, mako, xblock
@@ -166,7 +165,7 @@ newrelic==5.12.1.141      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.in
 numpy==1.18.4             # via chem, openedx-calc, scipy
-oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
+oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
 git+https://github.com/edx/edx-ora2.git@2.7.6#egg=ora2==2.7.6  # via -r requirements/edx/github.in
 packaging==20.3           # via bleach, drf-yasg
@@ -247,7 +246,7 @@ webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
-xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
+xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.3.1             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.in

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -91,7 +91,7 @@ git+https://github.com/edx/crowdsourcehinter.git@2178ac72891392106ffef389651aef3
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6
+# LTI consumer replaced by eduNEXT fork
 
 
 # Third Party XBlocks


### PR DESCRIPTION
Removed lti consumer from requirements/edx and downgraded lti-consumer to 1.2.6 same used in edx. 
Our version is v1.2.6.1, the same as edx but with `expose fullname` patch.

NOTE: the changes made in base.txt were made by `make edunext-upgrade` after changing lti-consumer version