### PR TITLE
ju/ednx/BC-19_P8: Fix #egg in lti-consumer/scorm xblock 

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -47,7 +47,7 @@ future==0.18.2            # via -c requirements/edunext/../edx/base.txt, pyjwkes
 idna==2.9                 # via -c requirements/edunext/../edx/base.txt, requests
 jsonfield2==3.0.3         # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 kombu==3.0.37             # via -c requirements/edunext/../edx/base.txt, celery
-git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=xblock-lti-consumer==v1.2.6.1  # via -r requirements/edunext/github.in
+git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer-xblock==v1.2.6.1  # via -r requirements/edunext/github.in
 lxml==4.5.0               # via -c requirements/edunext/../edx/base.txt, lti-consumer-xblock, parsel, xblock
 mako==1.0.2               # via -c requirements/edunext/../edx/base.txt, lti-consumer-xblock, schoolyourself-xblock, xblock-utils
 markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, mako, xblock
@@ -76,7 +76,7 @@ rest-condition==1.0.3     # via -c requirements/edunext/../edx/base.txt, edx-drf
 rsa==4.6                  # via python-jose
 rules==2.2                # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 git+https://github.com/schoolyourself/schoolyourself-xblock.git@2093048720cfb36cc05b3143cd6f2585c7c64d85#egg=schoolyourself-xblock  # via -r requirements/edunext/github.in
-git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.0#egg=edx_xblock_scorm==1.0.0  # via -r requirements/edunext/github.in
+git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.0#egg=scormxblock-xblock==1.0.0  # via -r requirements/edunext/github.in
 semantic-version==2.8.5   # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions
 sentry-sdk==0.14.3        # via eox-core
 simplejson==3.17.0        # via -c requirements/edunext/../edx/base.txt, xblock-utils

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -72,7 +72,7 @@ git+https://github.com/open-craft/xblock-vectordraw.git@v0.3.2#egg=vectordraw-xb
 git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1
 
 # eduNEXT supported xblocks
-git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.0#egg=edx_xblock_scorm==1.0.0
+git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.0#egg=scormxblock-xblock==1.0.0
 
 # Patched version that includes the fullname
-git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=xblock-lti-consumer==v1.2.6.1
+git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer-xblock==v1.2.6.1


### PR DESCRIPTION
Changed #egg in github.in so it's the same as the one used by edX -LTI CONSUMER-  or by edunext/ironwood release -SCORM-