### PR TITLE
ju/ednx/JU-11_P2: Add REGISTRATION_EXTRA_FIELDS to extra_fields

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -4,6 +4,7 @@ Objects and utilities used to construct registration forms.
 
 
 import copy
+from collections import OrderedDict
 from importlib import import_module
 import logging
 import re
@@ -364,16 +365,14 @@ class RegistrationFormFactory(object):
     @property
     def EXTRA_FIELDS(self):
         """eduNEXT: Property that returns extra fields list plus extended profile fields. This
-        property allows us to add custom fields to the registration form using extended_profile_fields.
+        property allows us to add custom fields to the registration form using extended_profile_fields and
+        REGISTRATION_EXTRA_FIELDS.
         """
         extended_profile_fields = getattr(settings, 'extended_profile_fields', [])
+        extra_fields = list(configuration_helpers.get_value('REGISTRATION_EXTRA_FIELDS', {}).keys())
 
-        # In case there's duplicates
-        if set(self.EXTRA_FIELDS_BASE) != set(extended_profile_fields):
-            difference = set(extended_profile_fields).difference(set(self.EXTRA_FIELDS_BASE))
-            return self.EXTRA_FIELDS_BASE + list(difference)
-
-        return self.EXTRA_FIELDS_BASE + extended_profile_fields
+        # Removing duplicates while mantaining order, important when running tests.
+        return list(OrderedDict.fromkeys(self.EXTRA_FIELDS_BASE + extended_profile_fields + extra_fields))
 
     def get_registration_form(self, request):
         """Return a description of the registration form.


### PR DESCRIPTION
This PR is a continuation of #458 

**Description and justification**

This change was done to be able to add extra fields without saving them as `extended_profile_fields`.

For example, say that we want to add a Confirmation Password field, the purpose of this field is to confirm the password so we don't need to save it.

To create these fields we only have to add them to: `REGISTRATION_EXTRA_FIELDS` and `REGISTRATION_FIELD_ORDER`