### PR TITLE
Fixed printing syntax error

### DIFF
--- a/common/lib/xmodule/xmodule/templates/problem/problem_with_hint.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/problem_with_hint.yaml
@@ -11,7 +11,7 @@ data: |
             <customresponse cfn="test_str" expect="python">
             <script type="text/python" system_path="python_lib">
     def test_str(expect, ans):
-      print expect, ans
+      print(expect, ans)
       ans = ans.strip("'")
       ans = ans.strip('"')
       return expect == ans.lower()
@@ -19,7 +19,7 @@ data: |
     def hint_fn(answer_ids, student_answers, new_cmap, old_cmap):
       aid = answer_ids[0]
       ans = str(student_answers[aid]).lower()
-      print 'hint_fn called, ans=', ans
+      print('hint_fn called, ans=', ans)
       hint = ''
       if 'java' in ans:
          hint = 'that is only good for drinking'


### PR DESCRIPTION
This PR fixes the printing error -in python 3.5- in problem_with_hint.yaml that affected the creation of problems with adaptive hints