### PR TITLE
Fix course about with edxnotes

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -42,14 +42,14 @@ log = logging.getLogger("edx.courseware")
 _ = lambda text: text
 
 
-@edxnotes
 @XBlock.needs("i18n")
-class HtmlBlock(
+class HtmlBlockMixin(
     XmlMixin, EditingMixin,
     XModuleDescriptorToXBlockMixin, XModuleToXBlockMixin, HTMLSnippet, ResourceTemplates, XModuleMixin,
 ):
     """
-    The HTML XBlock.
+    The HTML XBlock mixin.
+    This provides the base class for all Html-ish blocks (including the HTML XBlock).
     """
     display_name = String(
         display_name=_("Display Name"),
@@ -337,12 +337,12 @@ class HtmlBlock(
         """
         `use_latex_compiler` should not be editable in the Studio settings editor.
         """
-        non_editable_fields = super(HtmlBlock, self).non_editable_metadata_fields
-        non_editable_fields.append(HtmlBlock.use_latex_compiler)
+        non_editable_fields = super(HtmlBlockMixin, self).non_editable_metadata_fields
+        non_editable_fields.append(HtmlBlockMixin.use_latex_compiler)
         return non_editable_fields
 
     def index_dictionary(self):
-        xblock_body = super(HtmlBlock, self).index_dictionary()
+        xblock_body = super(HtmlBlockMixin, self).index_dictionary()
         # Removing script and style
         html_content = re.sub(
             re.compile(
@@ -368,6 +368,14 @@ class HtmlBlock(
         return xblock_body
 
 
+@edxnotes
+class HtmlBlock(HtmlBlockMixin):
+    """
+    This is the actual HTML XBlock.
+    Nothing extra is required; this is just a wrapper to include edxnotes support.
+    """
+
+
 class AboutFields(object):
     display_name = String(
         help=_("The display name for this component."),
@@ -382,7 +390,7 @@ class AboutFields(object):
 
 
 @XBlock.tag("detached")
-class AboutBlock(AboutFields, HtmlBlock):
+class AboutBlock(AboutFields, HtmlBlockMixin):
     """
     These pieces of course content are treated as HtmlBlocks but we need to overload where the templates are located
     in order to be able to create new ones
@@ -417,7 +425,7 @@ class StaticTabFields(object):
 
 
 @XBlock.tag("detached")
-class StaticTabBlock(StaticTabFields, HtmlBlock):
+class StaticTabBlock(StaticTabFields, HtmlBlockMixin):
     """
     These pieces of course content are treated as HtmlBlocks but we need to overload where the templates are located
     in order to be able to create new ones
@@ -442,7 +450,7 @@ class CourseInfoFields(object):
 
 
 @XBlock.tag("detached")
-class CourseInfoBlock(CourseInfoFields, HtmlBlock):
+class CourseInfoBlock(CourseInfoFields, HtmlBlockMixin):
     """
     These pieces of course content are treated as HtmlBlock but we need to overload where the templates are located
     in order to be able to create new ones


### PR DESCRIPTION
## Description
This is a backport from https://github.com/edx/edx-platform/pull/24930, ends the edxnotes html injection in course content xblocks.