### PR TITLE
Set font in order to support theme overrides.

### DIFF
--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -45,7 +45,8 @@
         ["\\[","\\]"],
         ['[mathjax]','[/mathjax]']
       ]
-    }
+    },
+    "HTML-CSS": { fonts: ["Latin-Modern"] }
   });
 </script>
 %endif


### PR DESCRIPTION
## Description 
this fixes the following error with math problems.
![image](https://user-images.githubusercontent.com/36200299/102143481-0221f980-3e32-11eb-83a4-66ed02612863.png)

this error only happens when the theme is different from the edx theme, specifically when the div font is changed, that was introduced in the following pr  https://github.com/edx/edx-platform/pull/20539 since they changed the config parameter from `TeX-MML-AM_SVG` to `TeX-MML-AM_HTMLorMML ` and in order to keep the previous changes, the font is set to `Latin-Modern`, since the default value doesn't work and that generates the error (default_value= TeX) in the current Mathjax version.
