### PR TITLE
Fixed building error on circleci

### DIFF
--- a/scripts/circle-ci-configuration.sh
+++ b/scripts/circle-ci-configuration.sh
@@ -59,7 +59,7 @@ if [ -f $FIREFOX_FILE ]; then
    echo "File $FIREFOX_FILE found."
 else
    echo "Downloading firefox-mozilla-build_61.0-0ubuntu1_amd64.deb."
-   wget -O $FIREFOX_FILE sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_61.0-0ubuntu1_amd64.deb
+   wget -O $FIREFOX_FILE sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_61.0.1-0ubuntu1_amd64.deb
 fi
 dpkg -i $FIREFOX_FILE || DEBIAN_FRONTEND=noninteractive apt-get -fyq install
 firefox --version


### PR DESCRIPTION
This PR solves this building error

![majo-help](https://user-images.githubusercontent.com/64440265/103354598-55c35280-4a82-11eb-8a8b-5d8c5a9f9bcf.png)

Apparently,  `sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_61.0-0ubuntu1_amd64.deb` was removed so it gave 302. When entering the link nothing happens besides some redirects