### PR TITLE
Fixing test failure due to 31-dec-2020 date issue

### DIFF
--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -175,7 +175,7 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
         self.assertIsNone(VerificationDeadline.deadline_for_course(self.course.id))
 
         # Generate the expected data
-        verification_deadline = datetime(year=2020, month=12, day=31, tzinfo=pytz.utc)
+        verification_deadline = datetime(year=2030, month=12, day=31, tzinfo=pytz.utc)
         expiration_datetime = datetime.now(pytz.utc)
         response, expected = self._get_update_response_and_expected_data(expiration_datetime, verification_deadline)
 


### PR DESCRIPTION
This PR fixes [this](https://app.circleci.com/pipelines/github/eduNEXT/edunext-platform/1334/workflows/0a59c82c-c782-4c7e-a9de-2ca69aab22a4/jobs/8776) error reported on circleci. The fix was taken from the master branch [edx/edx-platform](https://github.com/edx/edx-platform/pull/25961/files)