### PR TITLE
Added capability to ignore fields -in register form- when creating them 

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -679,6 +679,9 @@ class RegistrationFormFactory(object):
             field_name (str): Name used to get field information when creating it.
         """
         field_name = kwargs.pop("field_name")
+        if field_name in getattr(settings, "EDNX_IGNORE_REGISTER_FIELDS", []):
+            return
+
         custom_field_dict = self._get_custom_field_dict(field_name)
         if not custom_field_dict:
             log.error("Field with name {} must have a definition dictionary.".format(field_name))


### PR DESCRIPTION
This PR avoids raising errors when:

1. A field is added to REGISTRATION_EXTRA_FIELDS
2. We aren't interested in creating its definition dictionary because we don't want to render the field. For that, we don't want to raise any errors to not cause noise in sentry.

This is done to cover a special case with `authorized_email` field.

Now, to ignore it we will have to add the setting` EDNX_IGNORE_REGISTER_FIELDS : ["authorized_email"]`