### PR TITLE
Making the oauth2 tokens with grant client_credentials live for one year

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -5,6 +5,7 @@ Classes that override default django-oauth-toolkit behavior
 
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -80,6 +81,11 @@ class EdxOAuth2Validator(OAuth2Validator):
             # Ensure the tokens get associated with the correct user since DOT does not normally
             # associate access tokens issued with the client_credentials grant to users.
             request.user = request.client.user
+
+            # ednx: JU-10. Tokens for the machine-to-machine comunication should be longer lived
+            #       for backwards compatibility with eox-core and other plugin APIs.
+            #       Without this modification the BearerToken class will set this to 3600
+            request.expires_in = getattr(settings, 'CLIENT_CREDENTIALS_ACCESS_TOKEN_EXPIRE_SECONDS', 31557600)
 
         super(EdxOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
 


### PR DESCRIPTION
This PR modifies the oauth2 access tokens in a way such that when the grant_type = 'client_credentials' (machine to machine communication) the expiration time of the token is configurable via settings and has a default of one year.

Feature taken from https://github.com/eduNEXT/edunext-platform/pull/441