### PR TITLE
Adding the latest version of the surveymonkey-xblock

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -96,6 +96,7 @@ slumber==0.7.1            # via -c requirements/edunext/../edx/base.txt, edx-res
 social-auth-core==3.3.3   # via -c requirements/edunext/../edx/base.txt, eox-core
 sqlparse==0.3.1           # via -c requirements/edunext/../edx/base.txt, django
 stevedore==1.32.0         # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys
+git+https://github.com/Pearson-Advance/openedx-surveymonkey-xblock@v2.0.1#egg=surveymonkey-xblock==2.0.1  # via -r requirements/edunext/github.in
 ubcpi-xblock==1.0.0       # via -r requirements/edunext/base.in
 uritemplate==3.0.1        # via -c requirements/edunext/../edx/base.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -c requirements/edunext/../edx/base.txt, requests, sentry-sdk
@@ -107,7 +108,7 @@ webob==1.8.6              # via -c requirements/edunext/../edx/base.txt, xblock
 git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1  # via -r requirements/edunext/github.in
 git+https://github.com/edx-solutions/xblock-image-explorer.git@9a4ea322507f0f196aaf1283ce62aa017ed69e40#egg=xblock-image-explorer  # via -r requirements/edunext/github.in
 xblock-utils==2.1.1       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, lti-consumer-xblock, vectordraw-xblock, xblock-free-text-response, xblock-problem-builder
-xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, schoolyourself-xblock, scormxblock-xblock, ubcpi-xblock, vectordraw-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
+xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -68,6 +68,9 @@ git+https://github.com/schoolyourself/schoolyourself-xblock.git@2093048720cfb36c
 # Vector drawing xblock
 git+https://github.com/open-craft/xblock-vectordraw.git@v0.3.2#egg=vectordraw-xblock==0.3.2
 
+# Survey monkey xblock
+git+https://github.com/Pearson-Advance/openedx-surveymonkey-xblock@v2.0.1#egg=surveymonkey-xblock==2.0.1
+
 # Stanford xblocks
 git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1
 

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -6,4 +6,4 @@
 #
 click==7.1.2              # via pip-tools
 pip-tools==4.5.1          # via -c requirements/edx/../constraints.txt, -r requirements/edx/pip-tools.in
-six==1.14.0               # via -r requirements/edx/pip-tools.in, pip-tools
+six==1.15.0               # via -r requirements/edx/pip-tools.in, pip-tools


### PR DESCRIPTION
This PR includes surveymonkey-xblock into our supported list.

This is required for a customer migrating from a previous installation that supports this.

