### PR TITLE
Add authentication tests

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -30,7 +30,7 @@ class ClientCredentialsTest(mixins.AccessTokenMixin, TestCase):
             name='test dot application',
             user=self.user,
             authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri='{} {}'.format(DUMMY_REDIRECT_URL, 'http://testserver/'),
             client_id='dot-app-client-id',
         )
         scopes = ['read', 'write', 'email']

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -106,7 +106,7 @@ class CustomAuthorizationViewTestCase(TestCase):
         restricted_app = self.dot_adapter.create_confidential_client(
             name='test restricted dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri='{} {}'.format(DUMMY_REDIRECT_URL, 'http://testserver/'),
             client_id='dot-restricted-app-client-id',
         )
         models.RestrictedApplication.objects.create(application=restricted_app)

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -43,7 +43,7 @@ edx-when==1.2.3           # via -c requirements/edunext/../edx/base.txt, edx-pro
 eox-core[sentry,tpa]==4.3.0  # via -r requirements/edunext/base.in, eox-tagging
 eox-hooks==0.3.0          # via -r requirements/edunext/base.in
 eox-tagging==1.1.0        # via -r requirements/edunext/base.in
-eox-tenant==3.3.7         # via -r requirements/edunext/base.in
+eox-tenant==3.5.0         # via -r requirements/edunext/base.in
 eox-theming==1.1.0        # via -r requirements/edunext/base.in
 event-tracking==0.3.2     # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 flow-control-xblock==1.0.1  # via -r requirements/edunext/base.in


### PR DESCRIPTION
## Description 
Add authentication test in order to verify the following:
1) The token can only be created if the application redirect uris has the value of the current url request.
2) The token can only be used if the application redirect uris has the value of the current url request.

Update eox-tenant in order to add the tested behavior. 