### PR TITLE
Fix create users with usernames longer than 30 chars

### DIFF
--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -25,10 +25,10 @@ class TestLongUsernameEmail(TestCase):
 
     def test_long_username(self):
         """
-        Test username cannot be more than 30 characters long.
+        Test username cannot be more than 150 characters long.
         """
 
-        self.url_params['username'] = 'username' * 4
+        self.url_params['username'] = 'username' * 20
         response = self.client.post(self.url, self.url_params)
 
         # Status code should be 400.

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -25,6 +25,7 @@ from social_core.utils import module_member
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_current_request
+from openedx.core.djangoapps.user_api.accounts import USERNAME_MAX_LENGTH
 from openedx.core.lib.hash_utils import create_hash256
 
 from .lti import LTI_PARAMS_KEY, LTIAuthBackend
@@ -68,7 +69,7 @@ def clean_json(value, of_type):
 
 def clean_username(username=''):
     """ Simple helper method to ensure a username is compatible with our system requirements. """
-    return re.sub(r'[^-\w]+', '_', username)[:30]
+    return re.sub(r'[^-\w]+', '_', username)[:USERNAME_MAX_LENGTH]
 
 
 class AuthNotConfigured(SocialAuthBaseException):

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -77,8 +77,10 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
         ('S.K', 'S_K', False),
         ('S.K.', 'S_K_', False),
         ('S.K.', 'S_K_9fe2', True),
-        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlengthofm', False),
-        ('usernamewithcharacterlengthofmorethan30chars', 'usernamewithcharacterlengt9fe2', True),
+        ('usernamewithcharacterlenghtmorethan150chars' * 4,
+            ('usernamewithcharacterlenghtmorethan150chars' * 4)[:150], False),
+        ('usernamewithcharacterlenghtmorethan150chars' * 4,
+            ('usernamewithcharacterlenghtmorethan150chars' * 4)[:146] + '9fe2', True),
     )
     @ddt.unpack
     @mock.patch('third_party_auth.pipeline.user_exists')

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -15,7 +15,7 @@ NAME_MAX_LENGTH = 255
 
 # The minimum and maximum length for the username account field
 USERNAME_MIN_LENGTH = 2
-USERNAME_MAX_LENGTH = 30
+USERNAME_MAX_LENGTH = 150
 
 # The minimum and maximum length for the email account field
 EMAIL_MIN_LENGTH = 3

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -566,8 +566,10 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         ('pk', 'PK', 'Bob123', 'Bob123'),
         ('Pk', 'PK', None, ''),
         ('pK', 'PK', 'Bob123@edx.org', 'Bob123_edx_org'),
-        ('PK', 'PK', 'Bob123123123123123123123123123123123123', 'Bob123123123123123123123123123'),
-        ('us', 'US', 'Bob-1231231&23123+1231(2312312312@3123123123', 'Bob-1231231_23123_1231_2312312'),
+        ('PK', 'PK', 'Bob123123123123123123123123123123123123' * 4,
+            ('Bob123123123123123123123123123123123123' * 4)[:150]),
+        ('us', 'US', 'Bob-1231231&23123+1231(2312312312@3123123123' * 4,
+            ('Bob-1231231_23123_1231_2312312312_3123123123' * 4)[:150]),
     )
     @ddt.unpack
     def test_register_form_third_party_auth_running_google(


### PR DESCRIPTION
This PR changes the max length for usernames when creating users, the max was set to the maximum used by [Django](https://docs.djangoproject.com/en/3.1/ref/contrib/auth/#:~:text=150%20characters%20or%20fewer.,and%20%2D%20characters.) itself. This change affects the creation of the user by manual registration and using TPA providers like SAML.