### PR TITLE
Jhony/fix roles with no course

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -24,6 +24,7 @@ from contentstore.views.course import (
     get_courses_accessible_to_user
 )
 from course_action_state.models import CourseRerunState
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
@@ -316,30 +317,41 @@ class TestCourseListing(ModuleStoreTestCase):
         all of them.
         """
         org_course_one = self.store.make_course_key('AwesomeOrg', 'Course1', 'RunBabyRun')
-        CourseFactory.create(
+        course_1 = CourseFactory.create(
             org=org_course_one.org,
             number=org_course_one.course,
             run=org_course_one.run
         )
+        CourseOverviewFactory.create(id=course_1.id, org='AwesomeOrg')
 
         org_course_two = self.store.make_course_key('AwesomeOrg', 'Course2', 'RunBabyRun')
-        CourseFactory.create(
+        course_2 = CourseFactory.create(
             org=org_course_two.org,
             number=org_course_two.course,
             run=org_course_two.run
         )
+        CourseOverviewFactory.create(id=course_2.id, org='AwesomeOrg')
 
         # Two types of org-wide roles have edit permissions: staff and instructor.  We test both
         role.add_users(self.user)
 
-        with self.assertRaises(AccessListFallback):
-            _accessible_courses_list_from_groups(self.request)
         courses_list, __ = get_courses_accessible_to_user(self.request)
 
         # Verify fetched accessible courses list is a list of CourseSummery instances and test expacted
         # course count is returned
         self.assertEqual(len(list(courses_list)), 2)
         self.assertTrue(all(isinstance(course, CourseSummary) for course in courses_list))
+
+    @ddt.data(OrgStaffRole(), OrgInstructorRole())
+    def test_course_listing_org_permissions_exception(self, role):
+        """
+        Create roles with no course_id neither org to make sure AccessListFallback is raised for
+        platform-wide permissions
+        """
+        role.add_users(self.user)
+
+        with self.assertRaises(AccessListFallback):
+            _accessible_courses_list_from_groups(self.request)
 
     def test_course_listing_with_actions_in_progress(self):
         sourse_course_key = CourseLocator('source-Org', 'source-Course', 'source-Run')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -477,10 +477,20 @@ def _accessible_courses_list_from_groups(request):
     courses_list = []
     course_keys = {}
 
+    user_global_orgs = set()
     for course_access in all_courses:
-        if course_access.course_id is None:
+        if course_access.course_id is not None:
+            course_keys[course_access.course_id] = course_access.course_id
+        elif course_access.org:
+            user_global_orgs.add(course_access.org)
+        else:
             raise AccessListFallback
-        course_keys[course_access.course_id] = course_access.course_id
+
+    if user_global_orgs:
+        # Getting courses from user global orgs
+        overviews = CourseOverview.get_all_courses(orgs=list(user_global_orgs))
+        overviews_course_keys = {overview.id: overview.id for overview in overviews}
+        course_keys.update(overviews_course_keys)
 
     course_keys = list(course_keys.values())
 


### PR DESCRIPTION
This PR aims to solve the following issue:

The studio performance is degraded in /home and /settings/details/<course_id> pages when a user with global instructor or staff permissions over an organization (which maps to a Corse Access Role record with a defined role and org, but not course_id) tries to access them. This is because when getting the courses for a user in https://github.com/eduNEXT/edunext-platform/blob/49c83d61bc63c168d9445823e098ce1024ee880f/cms/djangoapps/contentstore/views/course.py#L466, if a Course Access Role with no course_id is found, the platform rises an exception in https://github.com/eduNEXT/edunext-platform/blob/49c83d61bc63c168d9445823e098ce1024ee880f/cms/djangoapps/contentstore/views/course.py#L482 which fallback to a method that also gets courses for the user but causes more overhead over the mongo database (https://github.com/eduNEXT/edunext-platform/blob/49c83d61bc63c168d9445823e098ce1024ee880f/cms/djangoapps/contentstore/views/course.py#L382)

This solution consists of not raising the exception when a Course Access Role does not have a course_id and just pulling all courses from organizations the user has access to globally. The CourseOverview model is used for that purpose. The exception AccessListFallback will only be raised if a Course Access Role record contains neither course_id nor org fields.

This PR was tested on stage. The loading time of these Studio pages under the conditions described above was improved