### PR TITLE
Change social-auth-core vesion

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -155,7 +155,8 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
         'id': 'id_value',
         'firstName': 'firstName_value',
         'idp_name': 'testshib',
-        'attributes': {u'urn:oid:0.9.2342.19200300.100.1.1': [u'myself']}
+        'attributes': {u'urn:oid:0.9.2342.19200300.100.1.1': [u'myself'], u'name_id': u'nameId_value'},
+        'session_index': 'sessionIndex_value',
     }
 
     @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,6 +90,9 @@ pytest-django<3.9.0
 # Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
 python-dateutil==2.4.0
 
+# social-auth-core==4.3.0 requires PyJWT > 2.0.0
+social-auth-core<4.0.3
+
 # transifex-client 0.13.5 and 0.13.6 needlessly pin six and urllib3, 0.13.7 does so for python-slugify
 #   https://github.com/transifex/transifex-client/issues/252
 transifex-client==0.13.4

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -94,7 +94,7 @@ shortuuid==1.0.1          # via django-oauth2-provider
 simplejson==3.17.0        # via -c requirements/edunext/../edx/base.txt, xblock-utils
 six==1.14.0               # via -c requirements/edunext/../edx/base.txt, bleach, cryptography, drf-yasg, ecdsa, edx-drf-extensions, edx-opaque-keys, event-tracking, fs, packaging, parsel, pyjwkest, python-dateutil, python-jose, social-auth-core, stevedore, w3lib, xblock, xblock-free-text-response
 slumber==0.7.1            # via -c requirements/edunext/../edx/base.txt, edx-rest-api-client
-social-auth-core==3.3.3   # via -c requirements/edunext/../edx/base.txt, eox-core
+social-auth-core==4.0.2   # via -c requirements/edunext/../edx/base.txt, eox-core
 sqlparse==0.3.1           # via -c requirements/edunext/../edx/base.txt, django
 stevedore==1.32.0         # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys
 git+https://github.com/Pearson-Advance/openedx-surveymonkey-xblock@v2.0.1#egg=surveymonkey-xblock==2.0.1  # via -r requirements/edunext/github.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -221,7 +221,7 @@ shapely==1.7.0            # via -r requirements/edx/base.in
 simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
 six==1.14.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/edx/base.in, social-auth-app-django
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
 soupsieve==2.0.1          # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -282,7 +282,7 @@ singledispatch==3.4.0.3   # via -r requirements/edx/testing.txt
 six==1.14.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pip-tools, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-social-auth-core==3.3.3   # via -r requirements/edx/testing.txt, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/edx/testing.txt, social-auth-app-django
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/testing.txt
 sortedcontainers==2.1.0   # via -r requirements/edx/testing.txt, pdfminer.six
 soupsieve==2.0.1          # via -r requirements/edx/testing.txt, beautifulsoup4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -270,7 +270,7 @@ simplejson==3.17.0        # via -r requirements/edx/base.txt, sailthru-client, s
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
 six==1.14.0               # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-core==3.3.3   # via -r requirements/edx/base.txt, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/edx/base.txt, social-auth-app-django
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/base.txt
 sortedcontainers==2.1.0   # via -r requirements/edx/base.txt, pdfminer.six
 soupsieve==2.0.1          # via -r requirements/edx/base.txt, beautifulsoup4


### PR DESCRIPTION
Change the current version of social-auth-core (3.3.3 to 4.0.2) in order to fix security vulnerabilities.