### PR TITLE
Add post register trigger

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -57,6 +57,7 @@ from openedx.core.djangoapps.user_authn.views.registration_form import (
     RegistrationFormFactory
 )
 from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
+from openedx.core.lib.triggers.v1 import post_register
 from student.helpers import (
     authenticate_new_user,
     create_or_set_user_attribute_created_on_site,
@@ -234,6 +235,9 @@ def create_account_with_params(request, params):
 
     # Announce registration
     REGISTER_USER.send(sender=None, user=user, registration=registration)
+
+    # This signal allows plugins to process the registration information after the account creation process
+    post_register.send_robust(sender=None, user=user)
 
     create_comments_service_user(user)
 

--- a/openedx/core/lib/triggers/v1.py
+++ b/openedx/core/lib/triggers/v1.py
@@ -22,3 +22,6 @@ pre_enrollment = django.dispatch.Signal(providing_args=[
 post_certificate_creation = django.dispatch.Signal(providing_args=[
     "certificate",
 ])
+
+# This signal fires after a user is registered on the platform
+post_register = django.dispatch.Signal(providing_args=["user"])


### PR DESCRIPTION
This PR adds the post register trigger.

The trigger was provisionally implemented with a signal in order to develop the  [UPC EXED post register Hook](https://3.basecamp.com/3966315/buckets/8050706/todos/3607953105#__recording_3636632623) feature.