### PR TITLE
fix: use github version of py2neo instead of PyPI

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -112,7 +112,6 @@ openedx-calc                        # Library supporting mathematical calculatio
 pdfminer.six                        # Used in shoppingcart for extracting/parsing pdf text
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts
 pycountry
 pycryptodomex

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -12,6 +12,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/github.in
 -e common/lib/safe_lxml  # via -r requirements/edx/local.in
 -e common/lib/sandbox-packages  # via -r requirements/edx/local.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -12,6 +12,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/testing.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -58,6 +58,7 @@ git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2
 
 # The latest 2.0.0 release doesn't yet support Django 2.2, this commit from master does
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=django-ratelimit

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -12,6 +12,7 @@
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
+-e git+https://github.com/technige/py2neo.git@py2neo-3.1.2#egg=py2neo==3.1.2  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/base.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/base.txt


### PR DESCRIPTION
Errors during the build:

py2neo
`ERROR: Could not find a version that satisfies the requirement py2neo==3.1.2 (from -r requirements/edx/testing.txt (line 211)) (from versions: 4.0.0, 4.1.0, 4.1.1, 4.1.2, 4.1.3, 4.2.0, 4.3.0, 2020.0.0, 2020.1.0, 2020.1.1, 2021.0.0, 2021.0.1)
ERROR: No matching distribution found for py2neo==3.1.2 (from -r requirements/edx/testing.txt (line 211))`


**Changes**

- Cherry-pick of this [commit](https://github.com/edx/edx-platform/commit/41b01c07eb10982589da6b6e55f70ba36d592d68#diff-94403e312c40bceb86487dcf9d3c34c45bc869c40190b74d335fd1812a7c2533), since the version of [Py2neo](https://pypi.org/project/py2neo/#history) the platform depends on, has been removed from PyPI. 
- Updated the .txt files according to this https://github.com/edx/edx-platform/pull/27186/commits/6230d6b34a02253dc4dc75467b1f66652401008a