### PR TITLE
Updating staff graded xblock to fix js bug

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -227,7 +227,7 @@ git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef793
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in, django
-staff-graded-xblock==0.8  # via -r requirements/edx/base.in
+staff-graded-xblock==1.1  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.8          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.5.1              # via symmath

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -297,7 +297,7 @@ sphinxcontrib-openapi[markdown]==0.6.0  # via -r requirements/edx/development.in
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/edx/testing.txt, django, django-debug-toolbar
-staff-graded-xblock==0.8  # via -r requirements/edx/testing.txt
+staff-graded-xblock==1.1  # via -r requirements/edx/testing.txt
 stevedore==1.32.0         # via -r requirements/edx/testing.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.8          # via -r requirements/edx/testing.txt, edx-bulk-grades
 sympy==1.5.1              # via -r requirements/edx/testing.txt, symmath

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -276,7 +276,7 @@ git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef793
 sortedcontainers==2.1.0   # via -r requirements/edx/base.txt, pdfminer.six
 soupsieve==2.0.1          # via -r requirements/edx/base.txt, beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.txt, django
-staff-graded-xblock==0.8  # via -r requirements/edx/base.txt
+staff-graded-xblock==1.1  # via -r requirements/edx/base.txt
 stevedore==1.32.0         # via -r requirements/edx/base.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.8          # via -r requirements/edx/base.txt, edx-bulk-grades
 sympy==1.5.1              # via -r requirements/edx/base.txt, symmath


### PR DESCRIPTION
This PR updates the version of the Staff Graded Points xblock to correct a bug when navigating a course with the xblock.

When a unit has a Staff Graded Points component, and you navigate the course as a student, the "Next"  and "Previous" button don't work. You can see it happening in prod [here](https://sitetestalbeironotdelete.edunext.io/courses/course-v1:albeiro-hawthorn-enero-2019+test-ironwood+2019_2/courseware/4ad6d1da6bf94363af4e7bfdeb22988d/f107301e00aa447083ff5302b774a191/?child=last)

This behavior was corrected in this commit https://github.com/edx/staff_graded-xblock/pull/18/commits/d8f60c789bde3552e98af520719fd7be5ddbf545 included in version 1.1

I tested it in stage [here](https://openedx-edunext-co.je.edunextstage.net/courses/course-v1:albeiro-hawthorn-enero-2019+CTR101+2021_T1/courseware/2d9aae4111d54fa0829900193e6f7f00/09e63156892c45a4b634435f449eccfd/?child=last) and the fix works correctly.

Note: I tried installing the latest version of the xblock (1.5) but it had some conflicts with Juniper.


