### PR TITLE
fix: performance of the instructor dashboard page

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -112,7 +112,7 @@ def instructor_dashboard_2(request, course_id):
         log.error(u"Unable to find course with course key %s while loading the Instructor Dashboard.", course_id)
         return HttpResponseServerError()
 
-    course = get_course_by_id(course_key, depth=0)
+    course = get_course_by_id(course_key, depth=None)
 
     access = {
         'admin': request.user.is_staff,


### PR DESCRIPTION
This PR aims to fix an issue impacting the performance of the instructor dashboard page.

## Description:

When loading the Instructor dashboard, the course is fetched with https://github.com/eduNEXT/edunext-platform/blob/master/lms/djangoapps/instructor/views/instructor_dashboard.py#L115. Please note that the parameter **depth** is zero, so the course is fetched with no children (sections, subsections, sequentials, etc). In a subsequent part of the code, the extensions tab is loaded, specifically in https://github.com/eduNEXT/edunext-platform/blob/master/lms/djangoapps/instructor/views/instructor_dashboard.py#L662, which eventually call the method **get_units_with_due_date** (https://github.com/eduNEXT/edunext-platform/blob/master/lms/djangoapps/instructor/views/tools.py#L123). This method iterates over the course and its children to find blocks with due dates. This iteration was taking too long unless the course is fetched with **depth** None, which brings all the children of the course, reason why this PR is created.

This was already tested in stage, where instructor dashboard load times were significantly improved.