### PR TITLE
feat: allow the user to create course modes

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -31,6 +31,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
@@ -397,19 +398,28 @@ def certificates_list_handler(request, course_key_string):
                 handler_name='certificate_activation_handler',
                 course_key=course_key
             )
+            course_mode_creation_url = reverse(
+                'course_modes_api:v1:course_modes_list',
+                args=(text_type(course_key),),
+            )
             course_modes = [
                 mode.slug for mode in CourseMode.modes_for_course(
                     course_id=course.id, include_expired=True
                 ) if mode.slug != 'audit'
             ]
+            # Check whether the audit mode associated with the course exists in database
+            has_audit_mode = CourseMode.objects.filter(course_id=course.id, mode_slug='audit')
 
             has_certificate_modes = len(course_modes) > 0
+
+            enable_course_mode_creation = settings.FEATURES.get('ENABLE_COURSE_MODE_CREATION', False)
 
             if has_certificate_modes:
                 certificate_web_view_url = get_lms_link_for_certificate_web_view(
                     course_key=course_key,
                     mode=course_modes[0]  # CourseMode.modes_for_course returns default mode if doesn't find anyone.
                 )
+                enable_course_mode_creation = False
             else:
                 certificate_web_view_url = None
 
@@ -419,6 +429,9 @@ def certificates_list_handler(request, course_key_string):
                 'context_course': course,
                 'certificate_url': certificate_url,
                 'course_outline_url': course_outline_url,
+                'course_mode_creation_url': course_mode_creation_url,
+                'enable_course_mode_creation': enable_course_mode_creation and not has_audit_mode,
+                'course_id': six.text_type(course_key),
                 'upload_asset_url': upload_asset_url,
                 'certificates': certificates,
                 'has_certificate_modes': has_certificate_modes,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -404,6 +404,19 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
     # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
+
+    # .. toggle_name: ENABLE_COURSE_MODE_CREATION
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable course mode creation through studio.
+    # .. toggle_category: n/a
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-06-21
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/eduNEXT/edunext-platform/pull/524
+    # .. toggle_status: supported
+    'ENABLE_COURSE_MODE_CREATION': False,
 }
 
 ENABLE_JASMINE = False


### PR DESCRIPTION
### **Description**
This PR allows the user to create course modes directly through the studio certificates view. This PR is just backend modifications, see #527 for the backbone components that form the rest of the feature.

https://3.basecamp.com/3966315/buckets/8050706/todos/3733330052

### **How to test**
Use instructions in PR #527 
