### PR TITLE
feat: expose course modes API to studio

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -175,6 +175,9 @@ urlpatterns = [
     url(r'^api/val/v0/', include('edxval.urls')),
     url(r'^api/tasks/v0/', include('user_tasks.urls')),
     url(r'^accessibility$', contentstore.views.accessibility, name='accessibility'),
+    # Course modes API for certificates generation
+    url(r'^api/course_modes/', include(('course_modes.api.urls', 'common.djangoapps.course_mods'),
+                                       namespace='course_modes_api')),
 ]
 
 if not settings.DISABLE_DEPRECATED_SIGNIN_URL:


### PR DESCRIPTION
This PR exposes the course modes API so we can create them in studio. Solves communication issues between Studio-LMS.

More context: https://3.basecamp.com/3966315/buckets/8050706/todos/3733330052