### PR TITLE
feat: create backbone app for course mode creation

### DIFF
--- a/cms/static/cms/js/build.js
+++ b/cms/static/cms/js/build.js
@@ -24,6 +24,7 @@
             'js/factories/export',
             'js/factories/group_configurations',
             'js/certificates/factories/certificates_page_factory',
+            'js/certificates/factories/course_mode_factory',
             'js/factories/index',
             'js/factories/manage_users',
             'js/factories/outline',

--- a/cms/static/cms/js/spec/main.js
+++ b/cms/static/cms/js/spec/main.js
@@ -280,7 +280,8 @@
         'js/certificates/spec/views/certificate_details_spec',
         'js/certificates/spec/views/certificate_editor_spec',
         'js/certificates/spec/views/certificates_list_spec',
-        'js/certificates/spec/views/certificate_preview_spec'
+        'js/certificates/spec/views/certificate_preview_spec',
+        'js/certificates/spec/views/add_course_mode_spec'
     ];
 
     i = 0;

--- a/cms/static/js/certificates/factories/course_mode_factory.js
+++ b/cms/static/js/certificates/factories/course_mode_factory.js
@@ -1,0 +1,15 @@
+define([
+    'jquery',
+    'js/certificates/views/add_course_mode'
+],
+function($, CourseModeHandler) {
+    'use strict';
+    return function(enableCourseModeCreation, courseModeCreationUrl, courseId) {
+        // Execute the page object's rendering workflow
+        new CourseModeHandler({
+            enableCourseModeCreation: enableCourseModeCreation,
+            courseModeCreationUrl: courseModeCreationUrl,
+            courseId: courseId
+        }).show();
+    };
+});

--- a/cms/static/js/certificates/spec/views/add_course_mode_spec.js
+++ b/cms/static/js/certificates/spec/views/add_course_mode_spec.js
@@ -1,0 +1,89 @@
+// Jasmine Test Suite: Course modes creation
+
+define([
+    'underscore',
+    'jquery',
+    'js/models/course',
+    'js/certificates/views/add_course_mode',
+    'common/js/spec_helpers/template_helpers',
+    'common/js/spec_helpers/view_helpers',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
+],
+function(_, $, Course, AddCourseMode, TemplateHelpers, ViewHelpers, AjaxHelpers) {
+    'use strict';
+
+    var SELECTORS = {
+        addCourseMode: '.add-course-mode'
+    };
+
+    describe('Add Course Modes Spec:', function() {
+        beforeEach(function() {
+            window.course = new Course({
+                id: '5',
+                name: 'Course Name',
+                url_name: 'course_name',
+                org: 'course_org',
+                num: 'course_num',
+                revision: 'course_rev'
+            });
+            window.CMS.User = {isGlobalStaff: true, isCourseInstructor: true};
+
+            TemplateHelpers.installTemplate('course-modes', true);
+            appendSetFixtures('<div class="wrapper-certificates nav-actions"></div>');
+            appendSetFixtures('<p class="account-username">test</p>');
+            this.view = new AddCourseMode({
+                el: $('.wrapper-certificates'),
+                courseId: window.course.id,
+                courseModeCreationUrl: '/api/course_modes/v1/courses/' + window.course.id + '/',
+                enableCourseModeCreation: true
+            });
+            appendSetFixtures(this.view.render().el);
+        });
+
+        afterEach(function() {
+            delete window.course;
+            delete window.CMS.User;
+        });
+
+        describe('Add course modes', function() {
+            it('course mode creation event works fine', function() {
+                spyOn(this.view, 'addCourseMode');
+                this.view.delegateEvents();
+                this.view.$(SELECTORS.addCourseMode).click();
+                expect(this.view.addCourseMode).toHaveBeenCalled();
+            });
+
+            it('add course modes button works fine', function() {
+                var requests = AjaxHelpers.requests(this),
+                    notificationSpy = ViewHelpers.createNotificationSpy();
+                this.view.$(SELECTORS.addCourseMode).click();
+                AjaxHelpers.expectJsonRequest(
+                    requests,
+                    'POST', '/api/course_modes/v1/courses/' + window.course.id + '/?username=test',
+                    {
+                        course_id: window.course.id,
+                        mode_slug: 'honor',
+                        mode_display_name: 'Honor',
+                        currency: 'usd'
+                    });
+                ViewHelpers.verifyNotificationShowing(notificationSpy, /Enabling honor course mode/);
+            });
+
+            it('enable course mode creation should be false when method "remove" called', function() {
+                this.view.remove();
+                expect(this.view.enableCourseModeCreation).toBe(false);
+            });
+
+            it('add course mode should be removed when method "remove" called', function() {
+                this.view.remove();
+                expect(this.view.el.innerHTML).toBe('');
+            });
+
+            it('method "show" should call the render function', function() {
+                spyOn(this.view, 'render');
+                this.view.show();
+                expect(this.view.render).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/cms/static/js/certificates/views/add_course_mode.js
+++ b/cms/static/js/certificates/views/add_course_mode.js
@@ -1,0 +1,70 @@
+define([
+    'underscore',
+    'gettext',
+    'js/views/baseview',
+    'common/js/components/views/feedback_notification',
+    'text!templates/course-modes.underscore',
+    'edx-ui-toolkit/js/utils/html-utils'
+],
+function(_, gettext, BaseView, NotificationView, CourseModes, HtmlUtils) {
+    'use strict';
+
+    var AddCourseMode = BaseView.extend({
+        el: $('.wrapper-certificates'),
+        events: {
+            'click .add-course-mode': 'addCourseMode'
+        },
+
+        initialize: function(options) {
+            this.enableCourseModeCreation = options.enableCourseModeCreation;
+            this.courseModeCreationUrl = options.courseModeCreationUrl;
+            this.courseId = options.courseId;
+        },
+
+        render: function() {
+            HtmlUtils.setHtml(this.$el, HtmlUtils.template(CourseModes)({
+                enableCourseModeCreation: this.enableCourseModeCreation,
+                courseModeCreationUrl: this.courseModeCreationUrl,
+                courseId: this.courseId
+            }));
+            return this;
+        },
+
+        addCourseMode: function() {
+            var notification = new NotificationView.Mini({
+                title: gettext('Enabling honor course mode')
+            });
+            var username = $('.account-username')[0].innerText;
+            $.ajax({
+                url: this.courseModeCreationUrl + '?username=' + username,
+                dataType: 'json',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    course_id: this.courseId,
+                    mode_slug: 'honor',
+                    mode_display_name: 'Honor',
+                    currency: 'usd'
+                }),
+                type: 'POST',
+                beforeSend: function() {
+                    notification.show();
+                },
+                success: function() {
+                    notification.hide();
+                    location.reload();
+                }
+            });
+        },
+
+        show: function() {
+            this.render();
+        },
+
+        remove: function() {
+            this.enableCourseModeCreation = false;
+            this.$el.empty();
+            return this;
+        }
+    });
+    return AddCourseMode;
+});

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -15,7 +15,7 @@ from openedx.core.djangolib.js_utils import (
 <%block name="bodyclass">is-signedin course view-certificates</%block>
 
 <%block name="header_extras">
-% for template_name in ["certificate-details", "certificate-editor", "signatory-editor", "signatory-details", "basic-modal", "modal-button", "list", "upload-dialog", "certificate-web-preview", "signatory-actions"]:
+% for template_name in ["certificate-details", "certificate-editor", "signatory-editor", "signatory-details", "basic-modal", "modal-button", "list", "upload-dialog", "certificate-web-preview", "signatory-actions", "course-modes"]:
   <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
   </script>
@@ -44,6 +44,15 @@ CMS.User.isCourseInstructor = '${is_course_instructor | n, js_escaped_string}'==
           ${certificate_web_view_url | n, dump_js_escaped_json},
           ${is_active | n, dump_js_escaped_json},
           ${certificate_activation_handler_url | n, dump_js_escaped_json}
+      );
+  });
+% endif
+% if enable_course_mode_creation:
+  require(["js/certificates/factories/course_mode_factory"], function(CourseModeFactory) {
+    CourseModeFactory(
+          ${enable_course_mode_creation | n, dump_js_escaped_json},
+          ${course_mode_creation_url | n, dump_js_escaped_json},
+          ${course_id | n, dump_js_escaped_json}
       );
   });
 % endif

--- a/cms/templates/js/course-modes.underscore
+++ b/cms/templates/js/course-modes.underscore
@@ -1,0 +1,6 @@
+<div class="no-content">
+<label for="add-course-mode"><%- gettext("Enable the honor mode for the course.") %></label>
+<a href="#" class="button new-button add-course-mode">
+    <% if ( enableCourseModeCreation ) { %> <%- gettext("Enable honor mode") %> <% } %>
+</a>
+</div>

--- a/webpack-config/file-lists.js
+++ b/webpack-config/file-lists.js
@@ -26,6 +26,7 @@ module.exports = {
         path.resolve(__dirname, '../cms/static/js/certificates/views/certificate_preview.js'),
         path.resolve(__dirname, '../cms/static/js/certificates/views/signatory_details.js'),
         path.resolve(__dirname, '../cms/static/js/certificates/views/signatory_editor.js'),
+        path.resolve(__dirname, '../cms/static/js/certificates/views/add_course_mode.js'),
         path.resolve(__dirname, '../cms/static/js/views/active_video_upload_list.js'),
         path.resolve(__dirname, '../cms/static/js/views/assets.js'),
         path.resolve(__dirname, '../cms/static/js/views/course_video_settings.js'),


### PR DESCRIPTION
### Description
This PR adds backbone necessary components to create course modes through studio. This version just creates the Honor course mode, that's one of the requirements to start generating certificates.

### How to test
Studio configuration
1. Add feature flag to turn on the feature (studio microsite settings)
```
    "FEATURES": {
        "ENABLE_COURSE_MODE_CREATION": true
    },
```
2. Ensure your course does not have a course mode (including audit)

https://user-images.githubusercontent.com/64440265/123441585-0332a100-d5a2-11eb-8058-f453ce78c3e1.mp4

