### PR TITLE
feat: add post enrollment trigger used to announce user's enrollment

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -77,7 +77,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 from student.signals import ENROLL_STATUS_CHANGE, ENROLLMENT_TRACK_UPDATED, UNENROLL_DONE
-from openedx.core.lib.triggers.v1 import pre_enrollment, TriggerException
+from openedx.core.lib.triggers.v1 import pre_enrollment, post_enrollment, TriggerException
 from track import contexts, segment
 from util.milestones_helpers import is_entrance_exams_enabled
 from util.model_utils import emit_field_changed_events, get_changed_fields_dict
@@ -1502,6 +1502,14 @@ class CourseEnrollment(models.Model):
         enrollment = cls.get_or_create_enrollment(user, course_key)
         enrollment.update_enrollment(is_active=True, mode=mode)
         enrollment.send_signal(EnrollStatusChange.enroll)
+
+        # Announce user's enrollment
+        post_enrollment.send_robust(
+            sender=None,
+            user=user,
+            course_key=course_key,
+            mode=mode,
+        )
 
         return enrollment
 

--- a/openedx/core/lib/triggers/v1.py
+++ b/openedx/core/lib/triggers/v1.py
@@ -18,6 +18,13 @@ pre_enrollment = django.dispatch.Signal(providing_args=[
     "mode",
 ])
 
+# Signal that fires after the user's enrollment
+post_enrollment = django.dispatch.Signal(providing_args=[
+    "user",
+    "course_key",
+    "mode",
+])
+
 # Signal that fires after a user's certificate is created
 post_certificate_creation = django.dispatch.Signal(providing_args=[
     "certificate",


### PR DESCRIPTION
**Description**
This PR adds the post-enrollment trigger for eox-hooks consumption. 

**Supporting information**
https://edunext.atlassian.net/browse/PS2021-916?atlOrigin=eyJpIjoiYmRiZmJiYzk0ZjkxNGJiN2FlYWU3ODU0ZjUwYjY4N2IiLCJwIjoiaiJ9

**Testing instructions**
1. Use the eox-hooks version where the post-enrollment signal is registered
2. Create a custom action in your favorite plugin
3. Add eox-hooks configuration to your site
3. Enroll in a course