### PR TITLE
feat: add xblock-pdf

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -109,8 +109,9 @@ git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b61418
 webob==1.8.6              # via -c requirements/edunext/../edx/base.txt, xblock
 git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1  # via -r requirements/edunext/github.in
 git+https://github.com/edx-solutions/xblock-image-explorer.git@9a4ea322507f0f196aaf1283ce62aa017ed69e40#egg=xblock-image-explorer  # via -r requirements/edunext/github.in
-xblock-utils==2.1.1       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, lti-consumer-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-problem-builder
-xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
+git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf  # via -r requirements/edunext/github.in
+xblock-utils==2.1.1       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, lti-consumer-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-pdf, xblock-problem-builder
+xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-pdf, xblock-problem-builder, xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -82,3 +82,6 @@ git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer
 
 # Webhook-xblock
 git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b6141803641f#egg=webhook-xblock==0.1.0
+
+# xblock-pdf
+git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf


### PR DESCRIPTION
I added the xblock-pdf to the github requirements.

I used this xblock: https://github.com/raccoongang/xblock-pdf because I considered it to be one of the most complete of those proposed in jira/basecamp and not as full of extras as other forks. This version supports translations (English, Portuguese, Arabic and French)

And most importantly, having it installed we can import courses with xblocks with pdf, such as:
https://storage.3.basecamp.com/3966315/blobs/696e09c6-f49e-11eb-840c-ecf4bbd72d92/download/course.P7LMM-30.lOm9c_.tar.gz?attachment=true

