### PR TITLE
fix: change the xblock repository

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -66,6 +66,7 @@ git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d
 packaging==20.3           # via -c requirements/edunext/../edx/base.txt, bleach, drf-yasg
 parsel==1.6.0             # via xblock-image-explorer
 pbr==5.4.5                # via -c requirements/edunext/../edx/base.txt, stevedore
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf  # via -r requirements/edunext/github.in
 psutil==1.2.1             # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via -c requirements/edunext/../edx/base.txt, cffi
@@ -109,9 +110,8 @@ git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b61418
 webob==1.8.6              # via -c requirements/edunext/../edx/base.txt, xblock
 git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1  # via -r requirements/edunext/github.in
 git+https://github.com/edx-solutions/xblock-image-explorer.git@9a4ea322507f0f196aaf1283ce62aa017ed69e40#egg=xblock-image-explorer  # via -r requirements/edunext/github.in
-git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf  # via -r requirements/edunext/github.in
-xblock-utils==2.1.1       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, lti-consumer-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-pdf, xblock-problem-builder
-xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-pdf, xblock-problem-builder, xblock-utils
+xblock-utils==2.1.1       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, lti-consumer-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-problem-builder
+xblock==1.3.1             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, lti-consumer-xblock, oppia-xblock, pdf-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -84,4 +84,4 @@ git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer
 git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b6141803641f#egg=webhook-xblock==0.1.0
 
 # xblock-pdf
-git+https://github.com/raccoongang/xblock-pdf.git@sgab-v.1.0.1#egg=xblock-pdf
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf


### PR DESCRIPTION
The repository that I was using before ([https://github.com/raccoongang/xblock-pdf](https://github.com/raccoongang/xblock-pdf)) was giving problems in production (the example pdf is not showing because of using http instead of https) and also had a styling problem.

I swapped it for this more up-to-date repository that solves these issues https://github.com/appsembler/pdfXBlock 

In stage: https://studio.je.edunextstage.net/container/block-v1:mafermazu+C3+2021+type@vertical+block@097ee5b9efde4a5eb380eaaac7c48ce6#