### PR TITLE
fix: change the egg of the requirement xblock pdf

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -66,7 +66,7 @@ git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d
 packaging==20.3           # via -c requirements/edunext/../edx/base.txt, bleach, drf-yasg
 parsel==1.6.0             # via xblock-image-explorer
 pbr==5.4.5                # via -c requirements/edunext/../edx/base.txt, stevedore
-git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf  # via -r requirements/edunext/github.in
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf-appsembler  # via -r requirements/edunext/github.in
 psutil==1.2.1             # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via -c requirements/edunext/../edx/base.txt, cffi

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -84,4 +84,4 @@ git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer
 git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b6141803641f#egg=webhook-xblock==0.1.0
 
 # xblock-pdf
-git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf-appsembler


### PR DESCRIPTION
Changing the xblock pdf requirement and keeping the egg (git+github.com/appsembler/pdfXBlock.git@v0.3.1 **#egg=xblock-pdf** ) in the `github.in` file caused the change to not be made correctly.

The first option to change the egg was: `xblock-pdf==0.3.1`
But when simulating productive (having an xblock already installed and installing another with the specified egg) it gave me the following warning.
![Screenshot from 2021-08-18 21-27-02](https://user-images.githubusercontent.com/35668326/130001148-339bc2a9-5b01-4611-ba70-e19189836457.png)


And I tried simulating productive with this other egg `xblock-pdf-appsembler`:
![Screenshot from 2021-08-18 21-29-39](https://user-images.githubusercontent.com/35668326/130001201-ac44670d-ff7e-4d21-b319-ce5897eac945.png)


When pip freeze is done it keeps a neutral name in both cases
![Screenshot from 2021-08-18 21-30-25](https://user-images.githubusercontent.com/35668326/130001243-a43ce201-2873-485a-8f63-7eb60114dbd4.png)

The package to keep is the pdf-xblock==0.3.1. I have to tell Jhony to remove the other if it is still in prod.
