### PR TITLE
fix: change the egg to pdf-xblock==0.3.1

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -66,7 +66,7 @@ git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d
 packaging==20.3           # via -c requirements/edunext/../edx/base.txt, bleach, drf-yasg
 parsel==1.6.0             # via xblock-image-explorer
 pbr==5.4.5                # via -c requirements/edunext/../edx/base.txt, stevedore
-git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf-appsembler  # via -r requirements/edunext/github.in
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=pdf-xblock==0.3.1  # via -r requirements/edunext/github.in
 psutil==1.2.1             # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via -c requirements/edunext/../edx/base.txt, cffi

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -84,4 +84,4 @@ git+https://github.com/eduNEXT/xblock-lti-consumer.git@v1.2.6.1#egg=lti_consumer
 git+https://github.com/eduNEXT/webhook-xblock@30d86f3878b513f8425eecde3252b6141803641f#egg=webhook-xblock==0.1.0
 
 # xblock-pdf
-git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=xblock-pdf-appsembler
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=pdf-xblock==0.3.1


### PR DESCRIPTION
Change `#egg=xblock-pdf-appsembler` to `#egg=pdf-xblock==0.3.1`.
The correct name of this project is `pdf-xblock` and the version was added to avoid confusion and follow the convention in the file.