### PR TITLE
[FFI-8] fix: upload artifacts after tests failure

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -73,6 +73,7 @@ jobs:
 
     - name: Save Job Artifacts
       uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
       with:
         name: Build-Artifacts
         path: |

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -65,6 +65,7 @@ jobs:
 
     - name: Save Job Artifacts
       uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
       with:
         name: Build-Artifacts
         path: |


### PR DESCRIPTION
**Description**
This PR allows uploading artifacts with detailed failure reports.

**How to**
1. Go to  the tests summary
![image](https://user-images.githubusercontent.com/64440265/138519694-917e6390-2f54-4322-a6ea-b5f9b413898c.png)
2. Download the artifact
3. Look for the failing tests. Example:
![image](https://user-images.githubusercontent.com/64440265/138519758-a4f98d0e-a9ad-40dd-bf79-4be2bd35c99f.png)
4. Check error messages. Example:
![image](https://user-images.githubusercontent.com/64440265/138519903-85cf9042-031c-4eba-80c4-b82f03618d98.png)