### PR TITLE
FFI-8: Install edunext requirements in github actions

### DIFF
--- a/.github/workflows/cms-tests.yml
+++ b/.github/workflows/cms-tests.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/common_tests_01.yml
+++ b/.github/workflows/common_tests_01.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/common_tests_02.yml
+++ b/.github/workflows/common_tests_02.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/lms-tests.yml
+++ b/.github/workflows/lms-tests.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/openedx_tests_01.yml
+++ b/.github/workflows/openedx_tests_01.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/openedx_tests_02.yml
+++ b/.github/workflows/openedx_tests_02.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/openedx_tests_03.yml
+++ b/.github/workflows/openedx_tests_03.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/openedx_tests_04.yml
+++ b/.github/workflows/openedx_tests_04.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests

--- a/.github/workflows/openedx_tests_05.yml
+++ b/.github/workflows/openedx_tests_05.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests

--- a/.github/workflows/openedx_tests_06.yml
+++ b/.github/workflows/openedx_tests_06.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests

--- a/.github/workflows/openedx_tests_07.yml
+++ b/.github/workflows/openedx_tests_07.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           sudo pip install --ignore-installed -r requirements/pip.txt
           sudo pip install --ignore-installed -r requirements/edx/testing.txt
+          sudo pip install --exists-action w -r requirements/edunext/base.txt
           sudo pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -52,7 +52,7 @@ jobs:
         PIP_SRC_DIR: ${{ runner.temp }}
       run: |
         pip install -r requirements/pip.txt
-        pip install -r requirements/edx/testing.txt -r requirements/edx/django.txt --src $PIP_SRC_DIR
+        pip install -r requirements/edx/testing.txt -r requirements/edx/django.txt -r requirements/edunext/base.txt --src $PIP_SRC_DIR
 
     - name: Run Quality Tests
       env:

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -4,4 +4,4 @@
 #
 #    make edunext-upgrade
 #
-eox-tenant==4.1.0         # via -r requirements/edunext/base.in
+eox-tenant==5.0.1         # via -r requirements/edunext/base.in

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -133,8 +133,6 @@ case "$TEST_SUITE" in
                 # This test was removed due to the uncertainty around which branch is currently used.
                 echo "Running PII checker on all Django models..."
                 run_paver_quality run_pii_check || { EXIT=1; }
-                echo "Running reserved keyword checker on all Django models..."
-                run_paver_quality check_keywords || { EXIT=1; }
                 ;;
 
         esac


### PR DESCRIPTION
Part 1 of FFI-8 
This PR installs the edunext requirements in GitHub actions since they are needed for the tests to pass.
It also removes the reserved keyword checker, since it has problems with our models