### PR TITLE
JU-6: add support for openedx-events

### DIFF
--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -11,6 +11,7 @@ import pytest
 from django.conf import settings
 from django.urls import reverse
 from edx_toggles.toggles.testutils import override_waffle_flag
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -33,10 +34,12 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 @override_waffle_flag(COURSEWARE_PROCTORING_IMPROVEMENTS, active=True)
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
-class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
+class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
     """
     Test student enrollment, especially with different course modes.
     """
+
+    ENABLED_OPENEDX_EVENTS = []
 
     USERNAME = "Bob"
     EMAIL = "bob@example.com"
@@ -45,7 +48,14 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
 
     @classmethod
     def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
         super().setUpClass()
+        cls.start_events_isolation()
         cls.course = CourseFactory.create()
         cls.course_limited = CourseFactory.create()
         cls.proctored_course = CourseFactory(

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -10,9 +10,26 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from django_countries.fields import Country
 
-from common.djangoapps.student.models import CourseEnrollmentAllowed
-from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
+from common.djangoapps.student.models import CourseEnrollmentAllowed, CourseEnrollment
+from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory, UserProfileFactory
 from common.djangoapps.student.tests.tests import UserSettingsEventTestMixin
+
+from openedx_events.learning.data import (
+    CourseData,
+    CourseEnrollmentData,
+    UserData,
+    UserPersonalData,
+)
+from openedx_events.learning.signals import (
+    COURSE_ENROLLMENT_CHANGED,
+    COURSE_ENROLLMENT_CREATED,
+    COURSE_UNENROLLMENT_COMPLETED,
+)
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class TestUserProfileEvents(UserSettingsEventTestMixin, TestCase):
@@ -180,3 +197,179 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
         # CEAs shouldn't have been affected
         assert CourseEnrollmentAllowed.objects.count() == 1
         assert CourseEnrollmentAllowed.objects.filter(email='test@edx.org').count() == 1
+
+
+@skip_unless_lms
+class EnrollmentEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the enrollment process through the enroll method.
+
+    This class guarantees that the following events are sent during the user's enrollment, with
+    the exact Data Attributes as the event definition stated:
+
+        - COURSE_ENROLLMENT_CREATED: sent after the user's enrollment.
+        - COURSE_ENROLLMENT_CHANGED: sent after the enrollment update.
+        - COURSE_UNENROLLMENT_COMPLETED: sent after the user's unenrollment.
+    """
+
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.course.enrollment.created.v1",
+        "org.openedx.learning.course.enrollment.changed.v1",
+        "org.openedx.learning.course.unenrollment.completed.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create(
+            username="test",
+            email="test@example.com",
+            password="password",
+        )
+        self.user_profile = UserProfileFactory.create(user=self.user, name="Test Example")
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_enrollment_created_event_emitted(self):
+        """
+        Test whether the student enrollment event is sent after the user's
+        enrollment process.
+
+        Expected result:
+            - COURSE_ENROLLMENT_CREATED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+        COURSE_ENROLLMENT_CREATED.connect(event_receiver)
+
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": COURSE_ENROLLMENT_CREATED,
+                "sender": None,
+                "enrollment": CourseEnrollmentData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.profile.name,
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=self.course.id,
+                        display_name=self.course.display_name,
+                    ),
+                    mode=enrollment.mode,
+                    is_active=enrollment.is_active,
+                    creation_date=enrollment.created,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )
+
+    def test_enrollment_changed_event_emitted(self):
+        """
+        Test whether the student enrollment changed event is sent after the enrollment
+        update process ends.
+
+        Expected result:
+            - COURSE_ENROLLMENT_CHANGED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+        COURSE_ENROLLMENT_CHANGED.connect(event_receiver)
+
+        enrollment.update_enrollment(mode="verified")
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": COURSE_ENROLLMENT_CHANGED,
+                "sender": None,
+                "enrollment": CourseEnrollmentData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.profile.name,
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=self.course.id,
+                        display_name=self.course.display_name,
+                    ),
+                    mode=enrollment.mode,
+                    is_active=enrollment.is_active,
+                    creation_date=enrollment.created,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )
+
+    def test_unenrollment_completed_event_emitted(self):
+        """
+        Test whether the student un-enrollment completed event is sent after the
+        user's unenrollment process.
+
+        Expected result:
+            - COURSE_UNENROLLMENT_COMPLETED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id)
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+        COURSE_UNENROLLMENT_COMPLETED.connect(event_receiver)
+
+        CourseEnrollment.unenroll(self.user, self.course.id)
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": COURSE_UNENROLLMENT_COMPLETED,
+                "sender": None,
+                "enrollment": CourseEnrollmentData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.profile.name,
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=self.course.id,
+                        display_name=self.course.display_name,
+                    ),
+                    mode=enrollment.mode,
+                    is_active=False,
+                    creation_date=enrollment.created,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -33,6 +33,9 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED, COURSE_CERT_CHANGED, COURSE_CERT_REVOKED
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 
+from openedx_events.learning.data import CourseData, UserData, UserPersonalData, CertificateData
+from openedx_events.learning.signals import CERTIFICATE_CHANGED, CERTIFICATE_CREATED, CERTIFICATE_REVOKED
+
 log = logging.getLogger(__name__)
 User = get_user_model()
 
@@ -361,6 +364,28 @@ class GeneratedCertificate(models.Model):
             status=self.status,
         )
 
+        CERTIFICATE_REVOKED.send_event(
+            certificate=CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
+                    ),
+                    id=self.user.id,
+                    is_active=self.user.is_active,
+                ),
+                course=CourseData(
+                    course_key=self.course_id,
+                ),
+                mode=self.mode,
+                grade=self.grade,
+                current_status=self.status,
+                download_url=self.download_url,
+                name=self.name,
+            )
+        )
+
     def mark_notpassing(self, grade):
         """
         Invalidates a Generated Certificate by marking it as notpassing
@@ -383,6 +408,28 @@ class GeneratedCertificate(models.Model):
             status=self.status,
         )
 
+        CERTIFICATE_REVOKED.send_event(
+            certificate=CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
+                    ),
+                    id=self.user.id,
+                    is_active=self.user.is_active,
+                ),
+                course=CourseData(
+                    course_key=self.course_id,
+                ),
+                mode=self.mode,
+                grade=self.grade,
+                current_status=self.status,
+                download_url=self.download_url,
+                name=self.name,
+            )
+        )
+
     def is_valid(self):
         """
         Return True if certificate is valid else return False.
@@ -403,6 +450,29 @@ class GeneratedCertificate(models.Model):
             mode=self.mode,
             status=self.status,
         )
+
+        CERTIFICATE_CHANGED.send_event(
+            certificate=CertificateData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
+                    ),
+                    id=self.user.id,
+                    is_active=self.user.is_active,
+                ),
+                course=CourseData(
+                    course_key=self.course_id,
+                ),
+                mode=self.mode,
+                grade=self.grade,
+                current_status=self.status,
+                download_url=self.download_url,
+                name=self.name,
+            )
+        )
+
         if CertificateStatuses.is_passing_status(self.status):
             COURSE_CERT_AWARDED.send_robust(
                 sender=self.__class__,
@@ -410,6 +480,28 @@ class GeneratedCertificate(models.Model):
                 course_key=self.course_id,
                 mode=self.mode,
                 status=self.status,
+            )
+
+            CERTIFICATE_CREATED.send_event(
+                certificate=CertificateData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=self.user.username,
+                            email=self.user.email,
+                            name=self.user.profile.name,
+                        ),
+                        id=self.user.id,
+                        is_active=self.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=self.course_id,
+                    ),
+                    mode=self.mode,
+                    grade=self.grade,
+                    current_status=self.status,
+                    download_url=self.download_url,
+                    name=self.name,
+                )
             )
 
 

--- a/lms/djangoapps/certificates/tests/test_events.py
+++ b/lms/djangoapps/certificates/tests/test_events.py
@@ -1,0 +1,227 @@
+"""
+Test classes for the events sent in the certification process.
+
+Classes:
+    CertificateEventTest: Test event sent after creating, changing or deleting
+    certificates.
+"""
+from unittest.mock import Mock
+
+from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import CERTIFICATE_CHANGED, CERTIFICATE_CREATED, CERTIFICATE_REVOKED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
+from lms.djangoapps.certificates.models import GeneratedCertificate, CertificateStatuses
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+
+
+@skip_unless_lms
+class CertificateEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the student's certification
+    process.
+
+    This class guarantees that the following events are sent during the user's
+    certification process, with the exact Data Attributes as the event definition stated:
+
+        - CERTIFICATE_CREATED: after the user's certificate generation has been
+        completed.
+        - CERTIFICATE_CHANGED: after the certificate update has been completed.
+        - CERTIFICATE_REVOKED: after the certificate revocation has been completed.
+    """
+
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.certificate.created.v1",
+        "org.openedx.learning.certificate.changed.v1",
+        "org.openedx.learning.certificate.revoked.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseOverviewFactory()
+        self.user = UserFactory.create(
+            username="somestudent",
+            first_name="Student",
+            last_name="Person",
+            email="robot@robot.org",
+            is_active=True
+        )
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_send_certificate_created_event(self):
+        """
+        Test whether the certificate created event is sent at the end of the
+        certificate creation process.
+
+        Expected result:
+            - CERTIFICATE_CREATED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        CERTIFICATE_CREATED.connect(event_receiver)
+
+        certificate = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course.id,
+            mode=GeneratedCertificate.MODES.honor,
+            name="Certificate",
+            grade="100",
+            download_url="https://certificate.pdf"
+        )
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": CERTIFICATE_CREATED,
+                "sender": None,
+                "certificate": CertificateData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=certificate.user.username,
+                            email=certificate.user.email,
+                            name=certificate.user.profile.name,
+                        ),
+                        id=certificate.user.id,
+                        is_active=certificate.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=certificate.course_id,
+                    ),
+                    mode=certificate.mode,
+                    grade=certificate.grade,
+                    current_status=certificate.status,
+                    download_url=certificate.download_url,
+                    name=certificate.name,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )
+
+    def test_send_certificate_changed_event(self):
+        """
+        Test whether the certificate changed event is sent at the end of the
+        certificate update process.
+
+        Expected result:
+            - CERTIFICATE_CHANGED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        CERTIFICATE_CHANGED.connect(event_receiver)
+        certificate = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course.id,
+            mode=GeneratedCertificate.MODES.honor,
+            name="Certificate",
+            grade="100",
+            download_url="https://certificate.pdf"
+        )
+
+        certificate.grade = "50"
+        certificate.save()
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": CERTIFICATE_CHANGED,
+                "sender": None,
+                "certificate": CertificateData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=certificate.user.username,
+                            email=certificate.user.email,
+                            name=certificate.user.profile.name,
+                        ),
+                        id=certificate.user.id,
+                        is_active=certificate.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=certificate.course_id,
+                    ),
+                    mode=certificate.mode,
+                    grade=certificate.grade,
+                    current_status=certificate.status,
+                    download_url=certificate.download_url,
+                    name=certificate.name,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )
+
+    def test_send_certificate_revoked_event(self):
+        """
+        Test whether the certificate revoked event is sent at the end of the
+        user certificate's revoking process.
+
+        Expected result:
+            - CERTIFICATE_REVOKED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        CERTIFICATE_REVOKED.connect(event_receiver)
+        certificate = GeneratedCertificateFactory.create(
+            status=CertificateStatuses.downloadable,
+            user=self.user,
+            course_id=self.course.id,
+            mode=GeneratedCertificate.MODES.honor,
+            name="Certificate",
+            grade="100",
+            download_url="https://certificate.pdf"
+        )
+
+        certificate.invalidate()
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": CERTIFICATE_REVOKED,
+                "sender": None,
+                "certificate": CertificateData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=certificate.user.username,
+                            email=certificate.user.email,
+                            name=certificate.user.profile.name,
+                        ),
+                        id=certificate.user.id,
+                        is_active=certificate.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=certificate.course_id,
+                    ),
+                    mode=certificate.mode,
+                    grade=certificate.grade,
+                    current_status=certificate.status,
+                    download_url=certificate.download_url,
+                    name=certificate.name,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -12,6 +12,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from opaque_keys.edx.locator import CourseKey, CourseLocator
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 from path import Path as path
 
 from common.djangoapps.student.tests.factories import AdminFactory, UserFactory
@@ -40,7 +41,7 @@ PLATFORM_ROOT = TEST_DIR.parent.parent.parent.parent
 TEST_DATA_ROOT = PLATFORM_ROOT / TEST_DATA_DIR
 
 
-class ExampleCertificateTest(TestCase):
+class ExampleCertificateTest(TestCase, OpenEdxEventsTestMixin):
     """Tests for the ExampleCertificate model. """
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
@@ -49,6 +50,19 @@ class ExampleCertificateTest(TestCase):
     TEMPLATE = 'test.pdf'
     DOWNLOAD_URL = 'http://www.example.com'
     ERROR_REASON = 'Kaboom!'
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -97,10 +111,24 @@ class ExampleCertificateTest(TestCase):
         assert result is None
 
 
-class CertificateHtmlViewConfigurationTest(TestCase):
+class CertificateHtmlViewConfigurationTest(TestCase, OpenEdxEventsTestMixin):
     """
     Test the CertificateHtmlViewConfiguration model.
     """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
     def setUp(self):
         super().setUp()
         self.configuration_string = """{
@@ -190,11 +218,24 @@ class CertificateTemplateAssetTest(TestCase):
         assert certificate_template_asset.asset == 'certificate_template_assets/1/picture2.jpg'
 
 
-class EligibleCertificateManagerTest(SharedModuleStoreTestCase):
+class EligibleCertificateManagerTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
     """
     Test the GeneratedCertificate model's object manager for filtering
     out ineligible certs.
     """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -235,10 +276,24 @@ class EligibleCertificateManagerTest(SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-class TestCertificateGenerationHistory(TestCase):
+class TestCertificateGenerationHistory(TestCase, OpenEdxEventsTestMixin):
     """
     Test the CertificateGenerationHistory model's methods
     """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
     @ddt.data(
         ({"student_set": "whitelisted_not_generated"}, "For exceptions", True),
         ({"student_set": "whitelisted_not_generated"}, "For exceptions", False),
@@ -293,10 +348,23 @@ class TestCertificateGenerationHistory(TestCase):
         assert certificate_generation_history.get_task_name() == expected
 
 
-class CertificateInvalidationTest(SharedModuleStoreTestCase):
+class CertificateInvalidationTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
     """
     Test for the Certificate Invalidation model.
     """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2021,7 +2021,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
             'failed': 0,
             'skipped': 2
         }
-        with self.assertNumQueries(170):
+        with self.assertNumQueries(178):
             self.assertCertificatesGenerated(task_input, expected_results)
 
         expected_results = {

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -16,6 +16,9 @@ from opaque_keys.edx.django.models import CourseKeyField
 
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
+from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
+
 log = logging.getLogger(__name__)
 
 
@@ -129,6 +132,24 @@ class CohortMembership(models.Model):
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.full_clean(validate_unique=False)
+
+        COHORT_MEMBERSHIP_CHANGED.send_event(
+            cohort=CohortData(
+                user=UserData(
+                    pii=UserPersonalData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        name=self.user.profile.name,
+                    ),
+                    id=self.user.id,
+                    is_active=self.user.is_active,
+                ),
+                course=CourseData(
+                    course_key=self.course_id,
+                ),
+                name=self.course_user_group.name,
+            )
+        )
 
         log.info("Saving CohortMembership for user '%s' in '%s'", self.user.id, self.course_id)
         return super().save(

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -12,6 +12,7 @@ from django.http import Http404
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.tests.factories import UserFactory
@@ -25,10 +26,23 @@ from ..tests.helpers import CohortFactory, CourseCohortFactory, config_course_co
 
 
 @patch("openedx.core.djangoapps.course_groups.cohorts.tracker", autospec=True)
-class TestCohortSignals(TestCase):
+class TestCohortSignals(TestCase, OpenEdxEventsTestMixin):
     """
     Test cases to validate event emissions for various cohort-related workflows
     """
+
+    ENABLED_OPENEDX_EVENTS = []
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/course_groups/tests/test_events.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_events.py
@@ -1,0 +1,108 @@
+"""
+Test classes for the events sent in the cohort assignment process.
+
+Classes:
+    CohortEventTest: Test event sent after cohort membership changes.
+"""
+from openedx.core.djangoapps.course_groups.models import CohortMembership
+from unittest.mock import Mock
+
+from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
+
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+
+
+@skip_unless_lms
+class CohortEventTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the cohort update process.
+
+    This class guarantees that the following events are sent during the user's
+    certification process, with the exact Data Attributes as the event definition stated:
+
+        - COHORT_MEMBERSHIP_CHANGED: when a cohort membership update ends.
+    """
+
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.cohort_membership.changed.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseOverviewFactory()
+        self.user = UserFactory.create(
+            username="somestudent",
+            first_name="Student",
+            last_name="Person",
+            email="robot@robot.org",
+            is_active=True
+        )
+        self.cohort = CohortFactory(course_id=self.course.id, name="FirstCohort")
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_send_cohort_membership_changed_event(self):
+        """
+        Test whether the COHORT_MEMBERSHIP_CHANGED event is sent when a cohort
+        membership update ends.
+
+        Expected result:
+            - COHORT_MEMBERSHIP_CHANGED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        COHORT_MEMBERSHIP_CHANGED.connect(event_receiver)
+
+        cohort_membership, _ = CohortMembership.assign(
+            cohort=self.cohort,
+            user=self.user,
+        )
+
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": COHORT_MEMBERSHIP_CHANGED,
+                "sender": None,
+                "cohort": CohortData(
+                    user=UserData(
+                        pii=UserPersonalData(
+                            username=cohort_membership.user.username,
+                            email=cohort_membership.user.email,
+                            name=cohort_membership.user.profile.name,
+                        ),
+                        id=cohort_membership.user.id,
+                        is_active=cohort_membership.user.is_active,
+                    ),
+                    course=CourseData(
+                        course_key=cohort_membership.course_id,
+                    ),
+                    name=cohort_membership.course_user_group.name,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -28,6 +28,8 @@ from edx_django_utils.monitoring import set_custom_attribute
 from ratelimit.decorators import ratelimit
 from rest_framework.views import APIView
 
+from openedx_events.learning.data import UserData, UserPersonalData
+from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -264,6 +266,19 @@ def _handle_successful_authentication_and_login(user, request):
         django_login(request, user)
         request.session.set_expiry(604800 * 4)
         log.debug("Setting user session expiry to 4 weeks")
+
+        # Announce user's login
+        SESSION_LOGIN_COMPLETED.send_event(
+            user=UserData(
+                pii=UserPersonalData(
+                    username=user.username,
+                    email=user.email,
+                    name=user.profile.name,
+                ),
+                id=user.id,
+                is_active=user.is_active,
+            ),
+        )
     except Exception as exc:
         AUDIT_LOG.critical("Login failed - Could not create session. Is memcached running?")
         log.critical("Login failed - Could not create session. Is memcached running?")

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -23,6 +23,8 @@ from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.debug import sensitive_post_parameters
 from edx_django_utils.monitoring import set_custom_attribute
 from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
+from openedx_events.learning.data import UserData, UserPersonalData
+from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED
 from pytz import UTC
 from ratelimit.decorators import ratelimit
 from requests import HTTPError
@@ -245,6 +247,18 @@ def create_account_with_params(request, params):
 
     # Announce registration
     REGISTER_USER.send(sender=None, user=user, registration=registration)
+
+    STUDENT_REGISTRATION_COMPLETED.send_event(
+        user=UserData(
+            pii=UserPersonalData(
+                username=user.username,
+                email=user.email,
+                name=user.profile.name,
+            ),
+            id=user.id,
+            is_active=user.is_active,
+        ),
+    )
 
     create_comments_service_user(user)
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_events.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_events.py
@@ -1,0 +1,183 @@
+"""
+Test classes for the events sent in the registration process.
+
+Classes:
+    RegistrationEventTest: Test event sent after registering a user through the
+    user API.
+    LoginSessionEventTest: Test event sent after creating the user's login session
+    user through the user API.
+"""
+from unittest.mock import Mock
+
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.urls import reverse
+from openedx_events.learning.data import UserData, UserPersonalData
+from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED, STUDENT_REGISTRATION_COMPLETED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+
+from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
+from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+
+@skip_unless_lms
+class RegistrationEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the registration process through
+    the registration view.
+
+    This class guarantees that the following events are sent after registering
+    a user, with the exact Data Attributes as the event definition stated:
+
+        - STUDENT_REGISTRATION_COMPLETED: after the user's registration has been
+        completed.
+    """
+
+    ENABLED_OPENEDX_EVENTS = ["org.openedx.learning.student.registration.completed.v1"]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        So the Open edX Events Isolation starts, the setUpClass must be explicitly
+        called with the method that executes the isolation. We do this to avoid
+        MRO resolution conflicts with other sibling classes while ensuring the
+        isolation process begins.
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.url = reverse("user_api_registration")
+        self.user_info = {
+            "email": "user@example.com",
+            "name": "Test User",
+            "username": "test",
+            "password": "password",
+            "honor_code": "true",
+        }
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_send_registration_event(self):
+        """
+        Test whether the student registration event is sent during the user's
+        registration process.
+
+        Expected result:
+            - STUDENT_REGISTRATION_COMPLETED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        STUDENT_REGISTRATION_COMPLETED.connect(event_receiver)
+
+        self.client.post(self.url, self.user_info)
+
+        user = User.objects.get(username=self.user_info.get("username"))
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": STUDENT_REGISTRATION_COMPLETED,
+                "sender": None,
+                "user": UserData(
+                    pii=UserPersonalData(
+                        username=user.username,
+                        email=user.email,
+                        name=user.profile.name,
+                    ),
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )
+
+
+@skip_unless_lms
+class LoginSessionEventTest(UserAPITestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the login process through the
+    login_user view.
+
+    This class guarantees that the following events are sent after the user's
+    session creation, with the exact Data Attributes as the event definition
+    stated:
+
+        - SESSION_LOGIN_COMPLETED: after login has been completed.
+    """
+
+    ENABLED_OPENEDX_EVENTS = ["org.openedx.learning.auth.session.login.completed.v1"]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.url = reverse('login_api')
+        self.user = UserFactory.create(
+            username="test",
+            email="test@example.com",
+            password="password",
+        )
+        self.user_profile = UserProfileFactory.create(user=self.user, name="Test Example")
+        self.receiver_called = True
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_send_login_event(self):
+        """
+        Test whether the student login event is sent after the user's
+        login process.
+
+        Expected result:
+            - SESSION_LOGIN_COMPLETED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = Mock(side_effect=self._event_receiver_side_effect)
+        SESSION_LOGIN_COMPLETED.connect(event_receiver)
+        data = {
+            "email": "test@example.com",
+            "password": "password",
+        }
+
+        self.client.post(self.url, data)
+
+        user = User.objects.get(username=self.user.username)
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": SESSION_LOGIN_COMPLETED,
+                "sender": None,
+                "user": UserData(
+                    pii=UserPersonalData(
+                        username=user.username,
+                        email=user.email,
+                        name=user.profile.name,
+                    ),
+                    id=user.id,
+                    is_active=user.is_active,
+                ),
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -21,6 +21,7 @@ from django.urls import NoReverseMatch, reverse
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
 from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordException,
@@ -43,10 +44,12 @@ from common.djangoapps.util.password_policy_validators import DEFAULT_MAX_PASSWO
 
 
 @ddt.ddt
-class LoginTest(SiteMixin, CacheIsolationTestCase):
+class LoginTest(SiteMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin):
     """
     Test login_user() view
     """
+
+    ENABLED_OPENEDX_EVENTS = []
 
     ENABLED_CACHES = ['default']
     LOGIN_FAILED_WARNING = 'Email or password is incorrect'
@@ -54,6 +57,17 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
     username = 'test'
     user_email = 'test@edx.org'
     password = 'test_password'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         """Setup a test user along with its registration and profile"""
@@ -948,12 +962,25 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
 
 @ddt.ddt
 @skip_unless_lms
-class LoginSessionViewTest(ApiTestCase):
+class LoginSessionViewTest(ApiTestCase, OpenEdxEventsTestMixin):
     """Tests for the login end-points of the user API. """
+
+    ENABLED_OPENEDX_EVENTS = []
 
     USERNAME = "bob"
     EMAIL = "bob@example.com"
     PASSWORD = "password"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -18,6 +18,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from pytz import UTC
 from social_django.models import Partial, UserSocialAuth
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
 from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.site_configuration.helpers import get_value
@@ -68,11 +69,15 @@ from common.djangoapps.util.password_policy_validators import (
 
 @ddt.ddt
 @skip_unless_lms
-class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCase, RetirementTestCase):
+class RegistrationViewValidationErrorTest(
+    ThirdPartyAuthTestMixin, UserAPITestCase, RetirementTestCase, OpenEdxEventsTestMixin
+):
     """
     Tests for catching duplicate email and username validation errors within
     the registration end-points of the User API.
     """
+
+    ENABLED_OPENEDX_EVENTS = []
 
     maxDiff = None
 
@@ -86,6 +91,17 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
     CITY = "Springfield"
     COUNTRY = "us"
     GOALS = "Learn all the things!"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -357,8 +373,12 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
 
 @ddt.ddt
 @skip_unless_lms
-class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
+class RegistrationViewTestV1(
+    ThirdPartyAuthTestMixin, UserAPITestCase, OpenEdxEventsTestMixin
+):
     """Tests for the registration end-points of the User API. """
+
+    ENABLED_OPENEDX_EVENTS = []
 
     maxDiff = None
 
@@ -419,6 +439,17 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
         }
     ]
     link_template = "<a href='/honor' rel='noopener' target='_blank'>{link_label}</a>"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):  # pylint: disable=arguments-differ
         super().setUp()
@@ -1746,6 +1777,17 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
 
     # pylint: disable=test-inherits-tests
 
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
     def setUp(self):  # pylint: disable=arguments-differ
         super(RegistrationViewTestV1, self).setUp()  # lint-amnesty, pylint: disable=bad-super-call
         self.url = reverse("user_api_registration_v2")
@@ -1974,15 +2016,30 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
 
 @httpretty.activate
 @ddt.ddt
-class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTestCase):
+class ThirdPartyRegistrationTestMixin(
+    ThirdPartyOAuthTestMixin, CacheIsolationTestCase, OpenEdxEventsTestMixin
+):
     """
     Tests for the User API registration endpoint with 3rd party authentication.
     """
     CREATE_USER = False
 
+    ENABLED_OPENEDX_EVENTS = []
+
     ENABLED_CACHES = ['default']
 
     __test__ = False
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()
@@ -2140,10 +2197,24 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestFacebookRegistrationView(
-    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase
+    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinFacebook, TransactionTestCase, OpenEdxEventsTestMixin
 ):
     """Tests the User API registration endpoint with Facebook authentication."""
+
+    ENABLED_OPENEDX_EVENTS = []
+
     __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def test_social_auth_exception(self):
         """
@@ -2158,20 +2229,47 @@ class TestFacebookRegistrationView(
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
 class TestGoogleRegistrationView(
-    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
+    ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase, OpenEdxEventsTestMixin
 ):
     """Tests the User API registration endpoint with Google authentication."""
+
+    ENABLED_OPENEDX_EVENTS = []
+
     __test__ = True
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
 
 @ddt.ddt
-class RegistrationValidationViewTests(test_utils.ApiTestCase):
+class RegistrationValidationViewTests(test_utils.ApiTestCase, OpenEdxEventsTestMixin):
     """
     Tests for validity of user data in registration forms.
     """
 
+    ENABLED_OPENEDX_EVENTS = []
+
     endpoint_name = 'registration_validation'
     path = reverse(endpoint_name)
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
 
     def setUp(self):
         super().setUp()

--- a/requirements/edunext/base.in
+++ b/requirements/edunext/base.in
@@ -29,6 +29,11 @@
 ###################
 eox-tenant                          # Edunext multi-tenant plugin, allows a multi-tenant instance.
 
+###################
+#   Libraries     #
+###################
+openedx-events                      # Open edX Events from Hooks Extension Framework (OEP-50)
+
 #####################
 # eduNEXT Xblocks #
 #####################

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -4,4 +4,14 @@
 #
 #    make edunext-upgrade
 #
+attrs==20.3.0             # via -c requirements/edunext/../edx/base.txt, openedx-events
+django==2.2.20            # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys, openedx-events
+edx-opaque-keys[django]==2.2.0  # via -c requirements/edunext/../edx/base.txt, openedx-events
 eox-tenant==5.0.1         # via -r requirements/edunext/base.in
+openedx-events==0.6.0     # via -r requirements/edunext/base.in
+pbr==5.5.1                # via -c requirements/edunext/../edx/base.txt, stevedore
+pymongo==3.10.1           # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys
+pytz==2021.1              # via -c requirements/edunext/../edx/base.txt, django
+six==1.15.0               # via -c requirements/edunext/../edx/base.txt, stevedore
+sqlparse==0.4.1           # via -c requirements/edunext/../edx/base.txt, django
+stevedore==1.32.0         # via -c requirements/edunext/../edx/base.txt, edx-opaque-keys


### PR DESCRIPTION
## Description

This PR adds support for Open edX Events in Limonero. These events are part of the [OEP-50: Hooks Extension Framework](https://open-edx-proposals.readthedocs.io/en/latest/oep-0050-hooks-extension-framework.html) implementation plan.

Since the OEP-50 publication, there has been a lot of discussion surrounding the design of this new extension point; I'll address some here for context:

- These events are defined in the library openedx-events and will be imported here to be triggered in a specific list of places. 
- The class `OpenEdxPublicSignal` -a subclass of Django signals- is used to create each event.
- `send_event` is the method that replaces `send` and `send_robust`.
- Each event sends payloads based on Data Attr classes. For more information: [Open edX Events Payload Conventions](https://github.com/eduNEXT/openedx-events/blob/main/docs/decisions/0003-events-payload.rst#3-open-edx-events-payload-conventions)
- Events unit test guarantees that they are being sent in the proper context. For example, `STUDENT_REGISTRATION_COMPLETED` is sent after the user's registration.

For an overall understanding of the design, check out the Open edX Events ADRs and discussions:

1. [Open edX Event naming and versioning ADR](https://github.com/eduNEXT/openedx-events/blob/main/docs/decisions/0002-events-naming-and-versioning.rst#2-open-edx-events-naming-and-versioning)
2. [Open edX Event Payload Conventions ADR](https://github.com/eduNEXT/openedx-events/blob/main/docs/decisions/0003-events-payload.rst#3-open-edx-events-payload-conventions)
3. [Community discussion about Open edX Events design](https://github.com/eduNEXT/openedx-events/pull/4#pullrequestreview-658570902)
4. [Community discussion about Hooks Extension Framework](https://discuss.openedx.org/t/configuration-for-the-hooks-extension-framework/)

## Supporting information

Discuss on Hooks Extension Framework:
https://discuss.openedx.org/t/configuration-for-the-hooks-extension-framework/4527/

## Testing instructions

1. Checkout to li/ednx/JU-6_P2
2. Install Open edX Events library:
`pip install openedx-events==0.6.0`
4. Connect your custom receiver to the signal as follows:
```
from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED

@receiver(STUDENT_REGISTRATION_COMPLETED)
def callback(**kwargs):
```