### PR TITLE
GI-10: Add support for metadata files that have more than one key.

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -172,6 +172,16 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"),
+        "[@use='signing']",
+        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate",
+    ))
+
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This feature adds support for metadata files that have more than one key. This is typical of instances of the ADSF from microsoft.

## Testing instructions

In the LMS:

- Go to https://openedx.edunext.co/admin/third_party_auth/samlproviderconfig/add/?source=77
copy all the configurations into a new /admin/third_party_auth/samlproviderconfig/add/ in you local environment. And create a SAML Configuration with this configuration: https://openedx.edunext.co/admin/third_party_auth/samlconfiguration/2/change/

- See that the fetched /admin/third_party_auth/samlproviderdata/ in your local environment is the same as the one for prod https://openedx.edunext.co/admin/third_party_auth/samlproviderdata/35/change/ or the one for the signing key at https://idp.dlbr.dk/federationmetadata/2007-06/federationmetadata.xml 

If the data is not being fetched, try to run the following command in the lms-shell:
manage.py lms saml --pull


## Additional information

- [Jira](https://edunext.atlassian.net/browse/PS2021-1158?atlOrigin=eyJpIjoiZDQ2YjhkNTAxOTY1NGFiMDgyMGJkZGMyMjNhNDBhOWYiLCJwIjoiaiJ9)
- [PR Juniper](https://github.com/eduNEXT/edunext-platform/pull/414)
- [Documentation](https://docs.google.com/document/d/1iotYv0VKXGaSfEjxf_GlLFdWL2eGiag5kCB-Ff_TE6U/edit#)

## Checklist for Merge

- [x] Tested in a remote environment (NA)
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [ X ] Check that dont't apply / NA
-->