### PR TITLE
li/ednx/BC-14 Add org roles

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -47,7 +47,10 @@ from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseStaffRole,
     GlobalStaff,
-    UserBasedRole
+    UserBasedRole,
+    CourseRerunCreatorRole,
+    OrgRerunCreatorRole,
+    OrgCourseCreatorRole,
 )
 from common.djangoapps.util.course import get_link_for_about_page
 from common.djangoapps.util.date_utils import get_default_time_display
@@ -304,10 +307,11 @@ def course_rerun_handler(request, course_key_string):
     GET
         html: return html page with form to rerun a course for the given course id
     """
-    # Only global staff (PMs) are able to rerun courses during the soft launch
-    if not GlobalStaff().has_user(request.user):
-        raise PermissionDenied()
     course_key = CourseKey.from_string(course_key_string)
+
+    if not GlobalStaff().has_user(request.user) and not _rerun_permission(request.user, course_key):
+        raise PermissionDenied()
+
     with modulestore().bulk_operations(course_key):
         course_module = get_course_and_check_access(course_key, request.user, depth=3)
         if request.method == 'GET':
@@ -550,6 +554,8 @@ def course_listing(request):
     split_archived = settings.FEATURES.get('ENABLE_SEPARATE_ARCHIVED_COURSES', False)
     active_courses, archived_courses = _process_courses_list(courses_iter, in_process_course_actions, split_archived)
     in_process_course_actions = [format_in_process_course_view(uca) for uca in in_process_course_actions]
+    active_courses = _set_rerun_permission_for_courses(user, active_courses)
+    archived_courses = _set_rerun_permission_for_courses(user, archived_courses)
 
     return render_to_response('index.html', {
         'courses': active_courses,
@@ -849,11 +855,17 @@ def _create_or_rerun_course(request):
     Returns the destination course_key and overriding fields for the new course.
     Raises DuplicateCourseError and InvalidKeyError
     """
-    if not auth.user_has_role(request.user, CourseCreatorRole()):
-        raise PermissionDenied()
-
     try:
         org = request.json.get('org')
+
+        rerun_permission = (
+            OrgRerunCreatorRole(org).has_user(request.user)
+            or OrgCourseCreatorRole(org).has_user(request.user)
+        )
+
+        if not auth.user_has_role(request.user, CourseCreatorRole()) and not rerun_permission:
+            raise PermissionDenied()
+
         course = request.json.get('number', request.json.get('course'))
         display_name = request.json.get('display_name')
         # force the start date for reruns and allow us to override start via the client
@@ -1863,3 +1875,24 @@ def _get_course_creator_status(user):
         course_creator_status = 'granted'
 
     return course_creator_status
+
+
+def _rerun_permission(user, course_key):
+    """
+    Helper method to check if user can rerun-course
+    """
+    return (
+        CourseRerunCreatorRole(course_key).has_user(user)
+        or OrgRerunCreatorRole(course_key.org).has_user(user)
+    )
+
+
+def _set_rerun_permission_for_courses(user, courses):
+    """
+    iterate over courses dict and set the key 'rerun_permission'
+    """
+    for course in courses:
+        course_key = CourseKey.from_string(course['course_key'])
+        course['rerun_permission'] = _rerun_permission(user, course_key)
+
+    return courses

--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -20,6 +20,6 @@ class OrganizationListView(View):
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
         """Returns organization list as json."""
-        organizations = get_organizations()
-        org_names_list = [(org["short_name"]) for org in organizations]
+        # EDUNEXT: Organizations list must not be visible for users, reason why an empty array is returned
+        org_names_list = []
         return HttpResponse(dump_js_escaped_json(org_names_list), content_type='application/json; charset=utf-8')  # lint-amnesty, pylint: disable=http-response-with-content-type-json

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -385,13 +385,13 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 3, 18),
-        (False, 'staff', None, 3, 18),
+        (True, 'staff', None, 3, 20),
+        (False, 'staff', None, 3, 20),
         # Base user has global staff access
-        (True, 'user', ORG, 3, 18),
-        (False, 'user', ORG, 3, 18),
-        (True, 'user', None, 3, 18),
-        (False, 'user', None, 3, 18),
+        (True, 'user', ORG, 3, 20),
+        (False, 'user', ORG, 3, 20),
+        (True, 'user', None, 3, 20),
+        (False, 'user', None, 3, 20),
     )
     @ddt.unpack
     def test_separate_archived_courses(self, separate_archived_courses, username, org, mongo_queries, sql_queries):

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -17,7 +17,8 @@ class TestOrganizationListing(TestCase):
         self.staff = UserFactory(is_staff=True)
         self.client.login(username=self.staff.username, password='test')
         self.org_names_listing_url = reverse('organizations')
-        self.org_short_names = ["alphaX", "betaX", "orgX"]
+        # EDUNEXT: Organizations list must not be visible for users, reason why an empty array is set
+        self.org_short_names = []
         for index, short_name in enumerate(self.org_short_names):
             add_organization(organization_data={
                 'name': 'Test Organization %s' % index,

--- a/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
+++ b/cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx
@@ -40,7 +40,7 @@ export function CourseOrLibraryListing(props) {
               </a>
               { item.lms_link && item.rerun_link &&
               <ul className="item-actions course-actions">
-                { allowReruns &&
+                { (allowReruns || item.rerun_permission) &&
                 <li className="action action-rerun">
                   <a
                     href={item.rerun_link}

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -7,6 +7,8 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import (
       dump_js_escaped_json
   )
+from opaque_keys.edx.keys import CourseKey
+from common.djangoapps.student.roles import OrgRerunCreatorRole, UserBasedRole
 %>
 
 <%inherit file="base.html" />
@@ -22,6 +24,21 @@ from openedx.core.djangolib.js_utils import (
 </%block>
 
 <%block name="content">
+
+  <%
+    org_course_creator_status = 'notgranted'
+    org_course_creator_allowed_org = []
+    all_roles = UserBasedRole(request.user, 'org_course_creator_group').courses_with_role()
+    if all_roles:
+        org_course_creator_status = 'granted'
+        org_course_creator_allowed_org = [x.org for x in all_roles]
+    else:
+        org_course_creator_status = 'notgranted'
+        org_course_creator_allowed_org = []
+    course_creator_permission_granted = course_creator_status == 'granted' or org_course_creator_status == 'granted'
+    course_creator_permission_denied = course_creator_status == 'unrequested' and org_course_creator_status != 'granted'
+  %>
+
 <div class="wrapper-mast wrapper">
   <header class="mast has-actions">
     <h1 class="page-header">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</h1>
@@ -31,7 +48,7 @@ from openedx.core.djangolib.js_utils import (
       <h3 class="sr">${_("Page Actions")}</h3>
       <ul>
         <li class="nav-item">
-          % if course_creator_status=='granted':
+          % if course_creator_permission_granted:
           <a href="#" class="button new-button new-course-button"><span class="icon fa fa-plus icon-inline" aria-hidden="true"></span>
               ${_("New Course")}</a>
           % elif course_creator_status=='disallowed_for_this_site' and settings.FEATURES.get('STUDIO_REQUEST_EMAIL',''):
@@ -53,7 +70,7 @@ from openedx.core.djangolib.js_utils import (
   <section class="content">
     <article class="content-primary" role="main">
 
-      % if course_creator_status=='granted':
+      % if course_creator_permission_granted:
       <div class="wrapper-create-element wrapper-create-course">
         <form class="form-create create-course course-info" id="create-course-form" name="create-course-form">
           <div class="wrap-error">
@@ -81,12 +98,20 @@ from openedx.core.djangolib.js_utils import (
                   <label for="new-course-org">${_("Organization")}</label>
                   ## Translators: This is an example for the name of the organization sponsoring a course, seen when filling out the form to create a new course. The organization name cannot contain spaces.
                   ## Translators: "e.g. UniversityX or OrganizationX" is a placeholder displayed when user put no data into this field.
-                  <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
-                  <span class="tip" id="tip-new-course-org">${Text(_("The name of the organization sponsoring the course. {strong_start}Note: The organization name is part of the course URL.{strong_end} This cannot be changed, but you can set a different display name in Advanced Settings later.")).format(
-                      strong_start=HTML('<strong>'),
-                      strong_end=HTML('</strong>'),
-                  )}</span>
-                  <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
+                   % if org_course_creator_allowed_org:
+                    <select class="new-course-org" id="new-course-org" name="new-course-org" required aria-describedby="tip-new-course-org tip-error-new-course-org">
+                      %for org in org_course_creator_allowed_org:
+                      <option value="${ org }">${ org }</option>
+                      %endfor
+                    </select>
+                  % else:
+                    <input class="new-course-org" id="new-course-org" type="text" name="new-course-org" required placeholder="${_('e.g. UniversityX or OrganizationX')}" aria-describedby="tip-new-course-org tip-error-new-course-org" />
+                    <span class="tip" id="tip-new-course-org">${Text(_("The name of the organization sponsoring the course. {strong_start}Note: The organization name is part of the course URL.{strong_end} This cannot be changed, but you can set a different display name in Advanced Settings later.")).format(
+                        strong_start=HTML('<strong>'),
+                        strong_end=HTML('</strong>'),
+                    )}</span>
+                    <span class="tip tip-error is-hiding" id="tip-error-new-course-org"></span>
+                  % endif
                 </li>
 
                 <li class="field text required" id="field-course-number">
@@ -372,7 +397,7 @@ from openedx.core.djangolib.js_utils import (
           </div>
         </div>
 
-        %if course_creator_status == "granted":
+        %if course_creator_permission_granted:
         <div class="notice-item has-actions">
           <div class="msg">
             <h3 class="title">${_('Create Your First Course')}</h3>
@@ -393,7 +418,7 @@ from openedx.core.djangolib.js_utils import (
       % endif
 
 
-      %if course_creator_status == "unrequested":
+      %if course_creator_permission_denied:
       <div class="wrapper wrapper-creationrights">
         <h3 class="title">
           <a href="#instruction-creationrights" class="ui-toggle-control show-creationrights"><span class="label">${_('Becoming a Course Creator in {studio_name}').format(studio_name=settings.STUDIO_SHORT_NAME)}</span> <span class="icon fa fa-times-circle" aria-hidden="true"></span></a>

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -292,6 +292,33 @@ class CourseBetaTesterRole(CourseRole):
 
 
 @register_access_role
+class CourseRerunCreatorRole(CourseRole):
+    """A course staff with ability to rerun"""
+    ROLE = 'rerun_creator'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
+class OrgRerunCreatorRole(OrgRole):
+    """An ORG staff with ability to rerun all courses"""
+    ROLE = 'org_rerun_creator_group'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
+class OrgCourseCreatorRole(OrgRole):
+    """An ORG staff with ability to create new courses"""
+    ROLE = 'org_course_creator_group'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(self.ROLE, *args, **kwargs)
+
+
+@register_access_role
 class LibraryUserRole(CourseRole):
     """
     A user who can view a library and import content from it, but not edit it.


### PR DESCRIPTION
This commit includes:
- Refactor course_creator_permissions
- calculating rerun permissions for archived courses
- Support for custom permissions on course create and rerun handlers
- Activating organizations app and fixing tests

Commit from previous migration: https://github.com/eduNEXT/edunext-platform/commit/fa4918416ed631e5aa410b71f32067da4b6f40d2
Documentation: https://docs.google.com/document/d/1rIITjfQTGaVQE6rZYYcyuCxRU8QOyvxAyFPE5hSuNaw/edit?pli=1#heading=h.txmiajiyqvs8


**Note**: when testing this feature in local make sure to collect the studio assets, and after that, login to studio with your test user from an incognito window. By doing this, we make sure the page is loading the updated `CourseOrLibraryListing.js` file and is able to display the re-run course option.
![bc-14](https://user-images.githubusercontent.com/35777155/140392130-45305ab5-61ea-4dc5-9b69-d157bc9945fd.png)
