### PR TITLE
fix: fix error message in TriggerException

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1451,7 +1451,7 @@ class CourseEnrollment(models.Model):
         try:
             hook_result = pre_enrollment.send(sender=None, user=user, course_key=course_key, mode=mode)
         except Exception as error:
-            raise TriggerException(error.message)  # pylint: disable=no-member
+            raise TriggerException(str(error))
 
         for receiver_func, func_response in hook_result:
             log.info(


### PR DESCRIPTION
**Description**
This PR changes `error.message` to the correct str(error). This error should've been fixed during the migration to juniper but wasn't, it seems that didn't affect the execution.

**How to test**
1. Add hooks settings:
```
    "EOX_HOOKS_DEFINITIONS": {
        "pre_enrollment": {
                "action": "can_perform_enrollment_by_tag",
                "fail_silently": False,
                "module": "eox_taylor.suits.lightbend.actions"
            }
    }
    USE_EOX_HOOKS: true,
```
2. In your course advanced settings, add:
```
{
    "tags": ["premium"]
}
```
3. Try enrolling in the course, no errors will be found in the LMS server, and the message ``Could not enroll`` will be displayed.
![image](https://user-images.githubusercontent.com/64440265/140096485-2f6b1219-b33b-4ceb-a100-b5a03ef00083.png)