### PR TITLE
Revert "GI-10: Add support for metadata files that have more than one key."

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -172,16 +172,6 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
-
-    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
-        etree.QName(SAML_XML_NS, "KeyDescriptor"),
-        "[@use='signing']",
-        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate",
-    ))
-
-    if signing_public_key and public_key != signing_public_key:
-        public_key = signing_public_key
-
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
Reverts eduNEXT/edunext-platform#568

Currently the only example we have of an ADFS authentication with SAML is that of SEGES with https://idp.dlbr.dk/federationmetadata/2007-06/federationmetadata.xml and it works with the current implementation of openedx. In other words, this GI-10 would no longer be necessary.

- [Documentation](https://docs.google.com/document/d/1iotYv0VKXGaSfEjxf_GlLFdWL2eGiag5kCB-Ff_TE6U/edit#)
- [Details of how to test it and discussion OpenedX](https://github.com/edx/edx-platform/pull/29176)
- [Jira card](https://edunext.atlassian.net/browse/PS2021-1158)