### PR TITLE
JU-3: CertificateGenerated.save proxy

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -443,8 +443,12 @@ class GeneratedCertificate(models.Model):
         As well as the COURSE_CERT_CHANGED for any save event.
         """
         super().save(*args, **kwargs)
+        if self._meta.proxy:
+            sending_class = self._meta.proxy_for_model
+        else:
+            sending_class = self.__class__
         COURSE_CERT_CHANGED.send_robust(
-            sender=self.__class__,
+            sender=sending_class,
             user=self.user,
             course_key=self.course_id,
             mode=self.mode,
@@ -475,7 +479,7 @@ class GeneratedCertificate(models.Model):
 
         if CertificateStatuses.is_passing_status(self.status):
             COURSE_CERT_AWARDED.send_robust(
-                sender=self.__class__,
+                sender=sending_class,
                 user=self.user,
                 course_key=self.course_id,
                 mode=self.mode,


### PR DESCRIPTION
**Description**
This PR allows sending CertificateGenerated signals with the appropriate sender, so the signal receivers work correctly.

**How to test**
_TEST 1: receivers are working_
1. Add a receiver in certificates/models.py
```
@receiver(COURSE_CERT_AWARDED, sender=GeneratedCertificate)
def received_cert_awarded_signal(sender, user, course_key, **kwargs):
    log.info("SIGNAL RECEIVED FROM: %s", type(sender))
```
2. Create a GeneratedCertificate using Django admin
3. Expected result:
`2021-11-23 19:26:58,171 INFO 596 [lms.djangoapps.certificates.models] [user 3] [ip 172.22.0.1] models.py:663 - SIGNAL RECEIVED FROM: <class 'django.db.models.base.ModelBase'>`

_TEST 2: prerequisite courses are working_
1. Configure course prerequisite
2. Complete the prerequisite course, check the user's milestones
3. Expected result: the student can access the course with the prerequisite

**Supporting information**
[Docs](https://docs.google.com/document/d/1BtEShTyy5I9g_noIX0vA70dp_Oq4dCqKjCUdQN9xM5o/edit?usp=sharing)