### PR TITLE
BFI-0 Que los clientes vean el copyright de eduNext en el footer de Studio

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -15,7 +15,12 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <div class="footer-content-primary">
       <div class="colophon">
+<<<<<<< HEAD
         <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
+=======
+        <!-- Since we are using eox-tenant in studio we can set the marketing urls and the platform-name, why  not ? -->
+        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a data-rel="edx.org" href="${getattr(settings, 'EDUNEXT_SITE_PAGE', marketing_link('ROOT'))}" rel="external">${getattr(settings, 'EDUNEXT_STUDIO_MESSAGE', settings.PLATFORM_NAME)}</a>.</p>
+>>>>>>> f0b099a2eb (Add settings for the studio copyright link and text.)
       </div>
 
         <nav class="nav-peripheral" aria-label="${_("Policies")}">

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -15,12 +15,8 @@ from openedx.core.djangolib.markup import HTML, Text
 
     <div class="footer-content-primary">
       <div class="colophon">
-<<<<<<< HEAD
-        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a href="${marketing_link('ROOT')}" rel="external">${settings.PLATFORM_NAME}</a>.</p>
-=======
         <!-- Since we are using eox-tenant in studio we can set the marketing urls and the platform-name, why  not ? -->
         <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a data-rel="edx.org" href="${getattr(settings, 'EDUNEXT_SITE_PAGE', marketing_link('ROOT'))}" rel="external">${getattr(settings, 'EDUNEXT_STUDIO_MESSAGE', settings.PLATFORM_NAME)}</a>.</p>
->>>>>>> f0b099a2eb (Add settings for the studio copyright link and text.)
       </div>
 
         <nav class="nav-peripheral" aria-label="${_("Policies")}">

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -16,7 +16,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="footer-content-primary">
       <div class="colophon">
         <!-- Since we are using eox-tenant in studio we can set the marketing urls and the platform-name, why  not ? -->
-        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a data-rel="edx.org" href="${getattr(settings, 'EDUNEXT_SITE_PAGE', marketing_link('ROOT'))}" rel="external">${getattr(settings, 'EDUNEXT_STUDIO_MESSAGE', settings.PLATFORM_NAME)}</a>.</p>
+        <p>&copy; ${datetime.now(pytz.timezone(settings.TIME_ZONE)).year} <a href="${getattr(settings, 'EDUNEXT_SITE_PAGE', marketing_link('ROOT'))}" rel="external">${getattr(settings, 'EDUNEXT_STUDIO_MESSAGE', settings.PLATFORM_NAME)}</a>.</p>
       </div>
 
         <nav class="nav-peripheral" aria-label="${_("Policies")}">


### PR DESCRIPTION
**background:**

- [x] Migrated Add settings for the studio copyright link and text. Commit [f0b099a](https://github.com/eduNEXT/edunext-platform/commit/f0b099a2ebc9164737e35ec0c7318f55063f7cef)
- [x] Added setting into tenant or microsite.

![Screenshot from 2021-11-25 12-23-58](https://user-images.githubusercontent.com/18581590/143482420-af75c37f-6055-4b33-a23a-ba7c17974769.png)

