### PR TITLE
BC-19_P3 opchore: Test xblocks supported for lilac/limonero.

### DIFF
--- a/requirements/edunext/base.in
+++ b/requirements/edunext/base.in
@@ -42,7 +42,10 @@ openedx-filters                     # Open edX Filters from Hooks Extension Fram
 #####################
 # eduNEXT Xblocks #
 #####################
+flow-control-xblock
 
 #####################
 # Community Xblocks #
 #####################
+ubcpi-xblock
+openedx-scorm-xblock                #new overhangio openedx

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -4,6 +4,7 @@
 #
 #    make edunext-upgrade
 #
+git+https://github.com/open-craft/xblock-activetable.git@v0.3#egg=activetable-xblock==0.3  # via -r requirements/edunext/github.in
 amqp==2.6.1               # via -c requirements/edunext/../edx/base.txt, kombu
 appdirs==1.4.4            # via -c requirements/edunext/../edx/base.txt, fs
 attrs==20.3.0             # via -c requirements/edunext/../edx/base.txt, openedx-events
@@ -15,6 +16,7 @@ chardet==4.0.0            # via -c requirements/edunext/../edx/base.txt, request
 coreapi==2.3.3            # via -c requirements/edunext/../edx/base.txt, drf-yasg
 coreschema==0.0.4         # via -c requirements/edunext/../edx/base.txt, coreapi, drf-yasg
 cryptography==3.2.1       # via -c requirements/edunext/../edx/base.txt, pyjwt, social-auth-core
+cssselect==1.1.0          # via parsel
 defusedxml==0.7.1         # via -c requirements/edunext/../edx/base.txt, python3-openid, social-auth-core
 django-crum==0.7.9        # via -c requirements/edunext/../edx/base.txt, edx-django-utils, edx-proctoring, eox-audit-model, eox-hooks
 django-filter==2.4.0      # via -c requirements/edunext/../edx/base.txt, eox-core
@@ -24,7 +26,7 @@ django-oauth-toolkit==1.3.2  # via -c requirements/edunext/../edx/base.txt, eox-
 django-oauth2-provider==0.2.6.1  # via eox-core
 django-waffle==2.1.0      # via -c requirements/edunext/../edx/base.txt, edx-django-utils, edx-drf-extensions, edx-proctoring, eox-core
 django-webpack-loader==0.7.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring
-django==2.2.20            # via -c requirements/edunext/../edx/base.txt, django-crum, django-filter, django-model-utils, django-oauth-toolkit, djangorestframework, drf-jwt, drf-yasg, edx-api-doc-tools, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, edx-when, eox-audit-model, eox-hooks, event-tracking, jsonfield2, openedx-events, openedx-filters, rest-condition
+django==2.2.20            # via -c requirements/edunext/../edx/base.txt, django-crum, django-filter, django-model-utils, django-oauth-toolkit, djangorestframework, drf-jwt, drf-yasg, edx-api-doc-tools, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-proctoring, edx-when, eox-audit-model, eox-hooks, event-tracking, jsonfield2, openedx-events, openedx-filters, rest-condition, xblock-free-text-response
 djangorestframework==3.12.4  # via -c requirements/edunext/../edx/base.txt, drf-jwt, drf-yasg, edx-api-doc-tools, edx-drf-extensions, edx-proctoring, eox-core, eox-hooks, rest-condition
 drf-jwt==1.19.0           # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions
 drf-yasg==1.20.0          # via -c requirements/edunext/../edx/base.txt, edx-api-doc-tools
@@ -32,7 +34,7 @@ ecdsa==0.17.0             # via python-jose
 edx-api-doc-tools==1.4.0  # via -c requirements/edunext/../edx/base.txt, eox-core
 edx-django-utils==3.16.0  # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-rest-api-client, edx-when
 edx-drf-extensions==6.5.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring, edx-when
-edx-opaque-keys[django]==2.2.0  # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-proctoring, edx-when, eox-core, eox-hooks, openedx-events
+edx-opaque-keys[django]==2.2.0  # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions, edx-proctoring, edx-when, eox-core, eox-hooks, flow-control-xblock, openedx-events
 edx-proctoring==3.8.5     # via -c requirements/edunext/../edx/base.txt, eox-core
 edx-rest-api-client==5.3.0  # via -c requirements/edunext/../edx/base.txt, edx-proctoring
 edx-when==2.0.0           # via -c requirements/edunext/../edx/base.txt, edx-proctoring
@@ -40,9 +42,10 @@ eox-audit-model==0.6.0    # via eox-core, eox-tagging
 eox-core[eox-audit,sentry,tpa]==5.0.3  # via -r requirements/edunext/base.in, eox-tagging
 eox-hooks==2.0.0          # via -r requirements/edunext/base.in
 eox-tagging==3.0.0        # via -r requirements/edunext/base.in
-eox-tenant==5.1.0         # via -r requirements/edunext/base.in
+eox-tenant==5.1.2         # via -r requirements/edunext/base.in
 eox-theming==2.0.0        # via -r requirements/edunext/base.in
 event-tracking==1.0.4     # via -c requirements/edunext/../edx/base.txt, edx-proctoring
+flow-control-xblock==1.0.1  # via -r requirements/edunext/base.in
 fs==2.0.18                # via -c requirements/edunext/../edx/base.txt, xblock
 future==0.18.2            # via -c requirements/edunext/../edx/base.txt, pyjwkest
 idna==2.10                # via -c requirements/edunext/../edx/base.txt, requests
@@ -51,14 +54,19 @@ itypes==1.2.0             # via -c requirements/edunext/../edx/base.txt, coreapi
 jinja2==2.11.3            # via -c requirements/edunext/../edx/base.txt, coreschema
 jsonfield2==3.0.3         # via -c requirements/edunext/../edx/base.txt, edx-proctoring, eox-audit-model
 kombu==4.6.11             # via -c requirements/edunext/../edx/base.txt, celery
-lxml==4.5.0               # via -c requirements/edunext/../edx/base.txt, xblock
-markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, jinja2, xblock
+lxml==4.5.0               # via -c requirements/edunext/../edx/base.txt, parsel, xblock
+mako==1.1.4               # via -c requirements/edunext/../edx/base.txt, schoolyourself-xblock, xblock-utils
+markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, jinja2, mako, xblock
 newrelic==6.2.0.156       # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 oauthlib==3.0.1           # via -c requirements/edunext/../edx/base.txt, django-oauth-toolkit, requests-oauthlib, social-auth-core
 openedx-events==0.6.0     # via -r requirements/edunext/base.in, eox-hooks
 openedx-filters==0.3.0    # via -r requirements/edunext/base.in
+openedx-scorm-xblock==12.0.0  # via -r requirements/edunext/base.in
+git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock  # via -r requirements/edunext/github.in
 packaging==20.9           # via -c requirements/edunext/../edx/base.txt, drf-yasg
+parsel==1.6.0             # via xblock-image-explorer
 pbr==5.5.1                # via -c requirements/edunext/../edx/base.txt, stevedore
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=pdf-xblock==0.3.1  # via -r requirements/edunext/github.in
 psutil==5.8.0             # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 pyasn1==0.4.8             # via python-jose, rsa
 pycparser==2.20           # via -c requirements/edunext/../edx/base.txt, cffi
@@ -79,20 +87,32 @@ rsa==4.8                  # via python-jose
 ruamel.yaml.clib==0.2.2   # via -c requirements/edunext/../edx/base.txt, ruamel.yaml
 ruamel.yaml==0.17.4       # via -c requirements/edunext/../edx/base.txt, drf-yasg
 rules==2.2                # via -c requirements/edunext/../edx/base.txt, edx-proctoring
+git+https://github.com/schoolyourself/schoolyourself-xblock.git@2093048720cfb36cc05b3143cd6f2585c7c64d85#egg=schoolyourself-xblock  # via -r requirements/edunext/github.in
+git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.1#egg=scormxblock-xblock==1.0.1  # via -r requirements/edunext/github.in
 semantic-version==2.8.5   # via -c requirements/edunext/../edx/base.txt, edx-drf-extensions
 sentry-sdk==0.14.3        # via eox-core
 shortuuid==1.0.8          # via django-oauth2-provider
-six==1.15.0               # via -c requirements/edunext/../edx/base.txt, cryptography, ecdsa, edx-drf-extensions, event-tracking, fs, pyjwkest, python-dateutil, social-auth-core, stevedore, xblock
+simplejson==3.17.2        # via -c requirements/edunext/../edx/base.txt, xblock-utils
+six==1.15.0               # via -c requirements/edunext/../edx/base.txt, cryptography, ecdsa, edx-drf-extensions, event-tracking, fs, parsel, pyjwkest, python-dateutil, social-auth-core, stevedore, w3lib, xblock, xblock-free-text-response
 slumber==0.7.1            # via -c requirements/edunext/../edx/base.txt, edx-rest-api-client
 social-auth-core==4.0.2   # via -c requirements/edunext/../edx/base.txt, eox-core
 sqlparse==0.4.1           # via -c requirements/edunext/../edx/base.txt, django
 stevedore==1.32.0         # via -c requirements/edunext/../edx/base.txt, edx-django-utils, edx-opaque-keys
+git+https://github.com/Pearson-Advance/openedx-surveymonkey-xblock@v2.0.2#egg=surveymonkey-xblock==2.0.2  # via -r requirements/edunext/github.in
+ubcpi-xblock==1.0.0       # via -r requirements/edunext/base.in
 uritemplate==3.0.1        # via -c requirements/edunext/../edx/base.txt, coreapi, drf-yasg
 urllib3==1.26.4           # via -c requirements/edunext/../edx/base.txt, requests, sentry-sdk
+git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblock==0.4  # via -r requirements/edunext/github.in
 vine==1.3.0               # via -c requirements/edunext/../edx/base.txt, amqp, celery
-web-fragments==1.0.0      # via -c requirements/edunext/../edx/base.txt, xblock
+w3lib==1.22.0             # via parsel
+web-fragments==1.0.0      # via -c requirements/edunext/../edx/base.txt, openedx-scorm-xblock, xblock, xblock-utils
+git+https://github.com/eduNEXT/webhook-xblock@a734c6de47cb61cba20bec4a4f3362ce625d47d1#egg=webhook-xblock==0.2.0_1  # via -r requirements/edunext/github.in
 webob==1.8.7              # via -c requirements/edunext/../edx/base.txt, xblock
-xblock==1.4.0             # via -c requirements/edunext/../edx/base.txt, edx-when
+git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1  # via -r requirements/edunext/github.in
+git+https://github.com/eduNEXT/xblock-image-explorer.git@update-lilac-import#egg=xblock-image-explorer==2.0  # via -r requirements/edunext/github.in
+git+https://github.com/open-craft/problem-builder.git@v5.0.0#egg=xblock-problem-builder==5.0.0  # via -r requirements/edunext/github.in
+xblock-utils==2.1.2       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-problem-builder
+xblock==1.4.0             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, openedx-scorm-xblock, oppia-xblock, pdf-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -51,3 +51,37 @@
 #####################
 # Community Xblocks #
 #####################
+
+
+# Oppia XBlock
+git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
+
+# Active table xblock
+git+https://github.com/open-craft/xblock-activetable.git@v0.3#egg=activetable-xblock==0.3
+
+# Image explorer xblock
+git+https://github.com/eduNEXT/xblock-image-explorer.git@update-lilac-import#egg=xblock-image-explorer==2.0
+
+# Problem builder xblock.
+git+https://github.com/open-craft/problem-builder.git@v5.0.0#egg=xblock-problem-builder==5.0.0
+
+# School yourself xblock
+git+https://github.com/schoolyourself/schoolyourself-xblock.git@2093048720cfb36cc05b3143cd6f2585c7c64d85#egg=schoolyourself-xblock
+
+# Vector drawing xblock
+git+https://github.com/open-craft/xblock-vectordraw.git@v0.4#egg=vectordraw-xblock==0.4
+
+# Survey monkey xblock
+git+https://github.com/Pearson-Advance/openedx-surveymonkey-xblock@v2.0.2#egg=surveymonkey-xblock==2.0.2
+
+# Stanford xblocks
+git+https://github.com/edx/xblock-free-text-response@release/v1.1.1#egg=xblock-free-text-response==1.1.1
+
+# eduNEXT supported xblocks
+git+https://github.com/eduNEXT/edx_xblock_scorm@v1.0.1#egg=scormxblock-xblock==1.0.1
+
+# Webhook-xblock
+git+https://github.com/eduNEXT/webhook-xblock@a734c6de47cb61cba20bec4a4f3362ce625d47d1#egg=webhook-xblock==0.2.0_1
+
+# xblock-pdf
+git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=pdf-xblock==0.3.1


### PR DESCRIPTION
# Update and test xblocks.

## Description

chore: Update to new version xblocks packages in `edunext/github.in`.

chore: restore edx imports.

feat: update surveymonkey and quit edunext lti.

Remove edunext xblock lti-costumer leaving only the edx version.

**extra**: 
 - Its necessary to have `pip install openedx_filters` in lms.

- xblocks list: https://docs.google.com/spreadsheets/d/15mDu3udkDCpbo_soPHkuAKa0xB1ZglpOyQ04ud6q6B4/edit?usp=sharing

## Checklist for Merge
- [x] Tested in local environment: stackbuilder  limonero local.
- [x] Tested in a remote environment: lilac stage
- [x] Rebased limonero.master
- [x] Squashed commits

## Extra:
The following xblock don't have errors in local but in stage present other issues:
- In stage `oppia` doesn't allows to edit de block.
- **Scorm** have two versions: edunext and new overhangio. Both have to be configured in stage(S3).
-  school_yourself works in lesson mode but not in review.
- `Webhook-xblock` seems like it work but its necessary to test things like the trigger

This is a doc  with the errors: https://docs.google.com/document/d/160gU8EnJ-o1pJgMjyVTy4ryP3J90JxNfITaBVGgBzXg/edit?usp=sharing