### PR TITLE
LI-16: Renable the old IDV views

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -119,7 +119,9 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         url = reverse('course_modes_choose', args=[str(self.course.id)])
         response = self.client.get(url)
 
-        start_flow_url = IDVerificationService.get_verify_location(course_id=self.course.id)
+        start_flow_url = IDVerificationService.get_verify_location('verify_student_start_flow',
+                                                                   course_id=self.course.id)
+        start_flow_url += "?purchase_workflow=single"
         # Check whether we were correctly redirected
         self.assertRedirects(response, start_flow_url, fetch_redirect_response=False)
 
@@ -270,7 +272,9 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
 
         # Since the only available track is professional ed, expect that
         # we're redirected immediately to the start of the payment flow.
-        start_flow_url = IDVerificationService.get_verify_location(course_id=self.course.id)
+        start_flow_url = IDVerificationService.get_verify_location('verify_student_start_flow',
+                                                                   course_id=self.course.id)
+        start_flow_url += "?purchase_workflow=single"
         self.assertRedirects(response, start_flow_url, fetch_redirect_response=False)
 
         # Now enroll in the course
@@ -314,7 +318,8 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         if expected_redirect == 'dashboard':
             redirect_url = reverse('dashboard')
         elif expected_redirect == 'start-flow':
-            redirect_url = IDVerificationService.get_verify_location(course_id=self.course.id)
+            redirect_url = IDVerificationService.get_verify_location('verify_student_start_flow',
+                                                                     course_id=self.course.id)
         else:
             self.fail("Must provide a valid redirect URL name")
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -111,7 +111,8 @@ class ChooseModeView(View):
         has_enrolled_professional = (CourseMode.is_professional_slug(enrollment_mode) and is_active)
         if CourseMode.has_professional_mode(modes) and not has_enrolled_professional:
             purchase_workflow = request.GET.get("purchase_workflow", "single")
-            redirect_url = IDVerificationService.get_verify_location(course_id=course_key)
+            verify_url = IDVerificationService.get_verify_location('verify_student_start_flow', course_id=course_key)
+            redirect_url = f"{verify_url}?purchase_workflow={purchase_workflow}"
             if ecommerce_service.is_enabled(request.user):
                 professional_mode = modes.get(CourseMode.NO_ID_PROFESSIONAL_MODE) or modes.get(CourseMode.PROFESSIONAL)
                 if purchase_workflow == "single" and professional_mode.sku:
@@ -309,7 +310,7 @@ class ChooseModeView(View):
             donation_for_course[str(course_key)] = amount_value
             request.session["donation_for_course"] = donation_for_course
 
-            verify_url = IDVerificationService.get_verify_location(course_id=course_key)
+            verify_url = IDVerificationService.get_verify_location('verify_student_start_flow', course_id=course_key)
             return redirect(verify_url)
 
     def _get_requested_mode(self, request_dict):

--- a/common/djangoapps/student/email_helpers.py
+++ b/common/djangoapps/student/email_helpers.py
@@ -55,7 +55,7 @@ def generate_proctoring_requirements_email_context(user, course_id):
         'course_name': course_module.display_name,
         'proctoring_provider': capwords(course_module.proctoring_provider.replace('_', ' ')),
         'proctoring_requirements_url': settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('faq', ''),
-        'id_verification_url': IDVerificationService.get_verify_location(),
+        'id_verification_url': IDVerificationService.get_verify_location('verify_student_verify_now', course_id),
     }
 
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -253,7 +253,7 @@ class ProctoringRequirementsEmailTests(EmailTemplateTagMixin, ModuleStoreTestCas
     def _get_fragments(self):
         course_module = modulestore().get_course(self.course.id)
         proctoring_provider = capwords(course_module.proctoring_provider.replace('_', ' '))
-        id_verification_url = IDVerificationService.get_verify_location()
+        id_verification_url = IDVerificationService.get_verify_location('verify_student_verify_now', self.course.id)
         return [
             (
                 "You are enrolled in {} at {}. This course contains proctored exams.".format(

--- a/lms/djangoapps/course_home_api/progress/v1/views.py
+++ b/lms/djangoapps/course_home_api/progress/v1/views.py
@@ -130,9 +130,12 @@ class ProgressTabView(RetrieveAPIView):
         verification_status = IDVerificationService.user_status(request.user)
         verification_link = None
         if verification_status['status'] is None or verification_status['status'] == 'expired':
-            verification_link = IDVerificationService.get_verify_location(course_id=course_key)
+            verification_link = IDVerificationService.get_verify_location('verify_student_verify_now',
+                                                                          course_id=course_key)
+
         elif verification_status['status'] == 'must_reverify':
-            verification_link = IDVerificationService.get_verify_location(course_id=course_key)
+            verification_link = IDVerificationService.get_verify_location('verify_student_reverify',
+                                                                          course_id=course_key)
         verification_data = {
             'link': verification_link,
             'status': verification_status['status'],

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -664,11 +664,11 @@ class VerificationDeadlineDate(DateSummary):
             'verification-deadline-passed': (_('Learn More'), ''),
             'verification-deadline-retry': (
                 _('Retry Verification'),
-                IDVerificationService.get_verify_location(),
+                IDVerificationService.get_verify_location('verify_student_reverify'),
             ),
             'verification-deadline-upcoming': (
                 _('Verify My Identity'),
-                IDVerificationService.get_verify_location(self.course_id),
+                IDVerificationService.get_verify_location('verify_student_verify_now', self.course_id),
             )
         }
 

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -674,7 +674,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             assert block.description ==\
                    'You must successfully complete verification before this date to qualify for a Verified Certificate.'
             assert block.link_text == 'Verify My Identity'
-            assert block.link == IDVerificationService.get_verify_location(course.id)
+            assert block.link == IDVerificationService.get_verify_location('verify_student_verify_now', course.id)
 
     def test_verification_deadline_date_retry(self):
         with freeze_time('2015-01-02'):
@@ -689,7 +689,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             assert block.description ==\
                    'You must successfully complete verification before this date to qualify for a Verified Certificate.'
             assert block.link_text == 'Retry Verification'
-            assert block.link == IDVerificationService.get_verify_location()
+            assert block.link == IDVerificationService.get_verify_location('verify_student_reverify')
 
     def test_verification_deadline_date_denied(self):
         with freeze_time('2015-01-02'):

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -20,6 +20,7 @@ from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.util.query import use_read_replica_if_available
 from lms.djangoapps.verify_student.message_types import VerificationExpiry
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
+from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
@@ -197,7 +198,7 @@ class Command(BaseCommand):
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification',
+            'lms_verification_link': IDVerificationService.email_reverify_url(),
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
+from django.urls import reverse
+
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import User
 from lms.djangoapps.verify_student.utils import is_verification_expiring_soon
@@ -48,7 +50,7 @@ class XBlockVerificationService:
         """
         Returns the URL for a user to verify themselves.
         """
-        return IDVerificationService.get_verify_location()
+        return IDVerificationService.get_verify_location('verify_student_reverify')
 
 
 class IDVerificationService:
@@ -231,12 +233,39 @@ class IDVerificationService:
             return 'ID Verified'
 
     @classmethod
-    def get_verify_location(cls, course_id=None):
+    def get_verify_location(cls, url_name, course_id=None):
         """
+        url_name is one of:
+            'verify_student_verify_now'
+            'verify_student_reverify'
+
         Returns a string:
-            Returns URL for IDV on Account Microfrontend
+            eduNEXT:
+            If `ENABLE_ACCOUNT_MFE` setting is true, returns URL for
+            IDV microfrontend.
+            Else, returns URL for corresponding view.
         """
-        location = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
-        if course_id:
-            location += '?course_id={}'.format(quote(str(course_id)))
+        location = ''
+        if getattr(settings, 'ENABLE_ACCOUNT_MFE', False):
+            location = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+            if course_id:
+                location += f'?course_id={quote(str(course_id))}'
+        else:
+            if course_id:
+                location = reverse(url_name, args=[str(course_id)])
+            else:
+                location = reverse(url_name)
         return location
+
+    @classmethod
+    def email_reverify_url(cls):
+        """
+        Return a URL string for reverification emails:
+            eduNEXT:
+            If `ENABLE_ACCOUNT_MFE` setting is true, returns URL for IDV microfrontend.
+            Else, returns URL for reverify view.
+        """
+        if getattr(settings, 'ENABLE_ACCOUNT_MFE', False):
+            return f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        else:
+            return f'{settings.LMS_ROOT_URL}{reverse("verify_student_reverify")}'

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -39,8 +39,9 @@ class TestProfEdVerification(ModuleStoreTestCase):
                 'course_modes_choose',
                 args=[str(self.course_key)]
             ),
-
-            'verify_student_start_flow': IDVerificationService.get_verify_location(self.course_key),
+            "verify_student_start_flow": IDVerificationService.get_verify_location(
+                "verify_student_start_flow", self.course_key,
+            ) + "?purchase_workflow=single",
         }
 
     def test_start_flow(self):

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -115,31 +115,6 @@ class TestIDVerificationService(ModuleStoreTestCase):
 
         assert expected_user_ids == verified_user_ids
 
-    def test_get_verify_location_no_course_key(self):
-        """
-        Test for the path to the IDV flow with no course key given
-        """
-        path = IDVerificationService.get_verify_location()
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
-        assert path == expected_path
-
-    def test_get_verify_location_from_course_id(self):
-        """
-        Test for the path to the IDV flow with a course ID
-        """
-        course = CourseFactory.create(org='Robot', number='999', display_name='Test Course')
-        path = IDVerificationService.get_verify_location(course.id)
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
-        assert path == (expected_path + '?course_id=Robot/999/Test_Course')
-
-    def test_get_verify_location_from_string(self):
-        """
-        Test for the path to the IDV flow with a course key string
-        """
-        path = IDVerificationService.get_verify_location('course-v1:edX+DemoX+Demo_Course')
-        expected_path = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
-        assert path == (expected_path + '?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course')
-
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @ddt.ddt

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -990,7 +990,8 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
 
     def _assert_redirects_to_verify_start(self, response, course_id, status_code=302):
         """Check that the page redirects to the "verify later" part of the flow. """
-        url = IDVerificationService.get_verify_location(course_id=course_id)
+        url = IDVerificationService.get_verify_location('verify_student_verify_now',
+                                                        course_id=course_id)
         self.assertRedirects(response, url, status_code, fetch_redirect_response=False)
 
     def _assert_redirects_to_upgrade(self, response, course_id):
@@ -1807,13 +1808,13 @@ class TestReverifyView(TestVerificationBase):
         """
         Test that a User can use re-verify link for initial verification.
         """
-        self._assert_reverify()
+        self._assert_can_reverify()
 
     def test_reverify_view_can_reverify_denied(self):
         # User has a denied attempt, so can re-verify
         attempt = self.create_and_submit_attempt_for_user(self.user)
         attempt.deny("error")
-        self._assert_reverify()
+        self._assert_can_reverify()
 
     def test_reverify_view_can_reverify_expired(self):
         # User has a verification attempt, but it's expired
@@ -1825,7 +1826,7 @@ class TestReverifyView(TestVerificationBase):
         attempt.save()
 
         # Allow the student to re-verify
-        self._assert_reverify()
+        self._assert_can_reverify()
 
     def test_reverify_view_can_reverify_pending(self):
         """ Test that the user can still re-verify even if the previous photo
@@ -1840,7 +1841,7 @@ class TestReverifyView(TestVerificationBase):
         self.create_and_submit_attempt_for_user(self.user)
 
         # Can re-verify because an attempt has already been submitted.
-        self._assert_reverify()
+        self._assert_can_reverify()
 
     def test_reverify_view_cannot_reverify_approved(self):
         # Submitted attempt has been approved
@@ -1848,7 +1849,7 @@ class TestReverifyView(TestVerificationBase):
         attempt.approve()
 
         # Cannot re-verify because the user is already verified.
-        self._assert_reverify()
+        self._assert_cannot_reverify()
 
     @override_settings(VERIFY_STUDENT={"DAYS_GOOD_FOR": 5, "EXPIRING_SOON_WINDOW": 10})
     def test_reverify_view_can_reverify_approved_expired_soon(self):
@@ -1862,13 +1863,28 @@ class TestReverifyView(TestVerificationBase):
         attempt.approve()
 
         # Can re-verify because verification is set to expired soon.
-        self._assert_reverify()
+        self._assert_can_reverify()
 
-    def _assert_reverify(self):
+    def _get_reverify_page(self):
+        """
+        Retrieve the re-verification page and return the response.
+        """
         url = reverse("verify_student_reverify")
-        response = self.client.get(url)
-        verification_start_url = IDVerificationService.get_verify_location()
-        self.assertRedirects(response, verification_start_url, fetch_redirect_response=False)
+        return self.client.get(url)
+
+    def _assert_can_reverify(self):
+        """
+        Check that the re-verification flow is rendered.
+        """
+        response = self._get_reverify_page()
+        self.assertContains(response, "reverify-container")
+
+    def _assert_cannot_reverify(self):
+        """
+        Check that the user is blocked from re-verifying.
+        """
+        response = self._get_reverify_page()
+        self.assertContains(response, "reverify-blocked")
 
 
 @override_settings(

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -496,7 +496,7 @@ class PayAndVerifyView(View):
             if is_enrolled:
                 if already_paid:
                     # If the student has paid, but not verified, redirect to the verification flow.
-                    url = IDVerificationService.get_verify_location(str(course_key))
+                    url = IDVerificationService.get_verify_location('verify_student_verify_now', str(course_key))
             else:
                 url = reverse('verify_student_start_flow', kwargs=course_kwargs)
 
@@ -1143,7 +1143,7 @@ def results_callback(request):  # lint-amnesty, pylint: disable=too-many-stateme
     elif result == "FAIL":
         log.debug("Denying verification for %s", receipt_id)
         attempt.deny(json.dumps(reason), error_code=error_code)
-        reverify_url = f'{settings.ACCOUNT_MICROFRONTEND_URL}/id-verification'
+        reverify_url = IDVerificationService.email_reverify_url()
         verification_status_email_vars['reasons'] = reason
         verification_status_email_vars['reverify_url'] = reverify_url
         verification_status_email_vars['faq_url'] = settings.ID_VERIFICATION_SUPPORT_LINK
@@ -1236,8 +1236,22 @@ class ReverifyView(View):
         Most of the work is done client-side by composing the same
         Backbone views used in the initial verification flow.
         """
-        IDV_workflow = IDVerificationService.get_verify_location()
-        return redirect(IDV_workflow)
+        verification_status = IDVerificationService.user_status(request.user)
+        expiration_datetime = IDVerificationService.get_expiration_datetime(request.user, ['approved'])
+        if can_verify_now(verification_status, expiration_datetime):
+            if getattr(settings, 'ENABLE_ACCOUNT_MFE', False):
+                return redirect(IDVerificationService.get_verify_location('verify_student_reverify'))
+            context = {
+                "user_full_name": request.user.profile.name,
+                "platform_name": configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+                "capture_sound": staticfiles_storage.url("audio/camera_capture.wav"),
+            }
+            return render_to_response("verify_student/reverify.html", context)
+        else:
+            context = {
+                "status": verification_status['status']
+            }
+            return render_to_response("verify_student/reverify_not_allowed.html", context)
 
 
 class PhotoUrlsView(APIView):

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -29,7 +29,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
 %>
 
 <%
-  reverify_link = IDVerificationService.get_verify_location()
+  reverify_link = IDVerificationService.get_verify_location('verify_student_reverify')
   cert_name_short = course_overview.cert_name_short
   if cert_name_short == "":
     cert_name_short = settings.CERT_NAME_SHORT
@@ -375,7 +375,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % endif
               </div>
               <div class="verification-cta">
-                <a href="${IDVerificationService.get_verify_location(course_overview.id)}" class="btn" data-course-id="${course_overview.id}">${_('Verify Now')}</a>
+                <a href="${IDVerificationService.get_verify_location('verify_student_verify_now', course_overview.id)}" class="btn" data-course-id="${course_overview.id}">${_('Verify Now')}</a>
               </div>
             % elif verification_status['status'] == VERIFY_STATUS_SUBMITTED:
               <h4 class="message-title">${_('You have submitted your verification information.')}</h4>
@@ -393,7 +393,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
               ## Translators: start_link and end_link will be replaced with HTML tags;
               ## please do not translate these.
               <p class="message-copy">${Text(_('Your current verification will expire in {days} days. {start_link}Re-verify your identity now{end_link} using a webcam and a government-issued photo ID.')).format(
-                  start_link=HTML('<a href="{href}">').format(href=IDVerificationService.get_verify_location()),
+                  start_link=HTML('<a href="{href}">').format(href=IDVerificationService.get_verify_location('verify_student_reverify')),
                   end_link=HTML('</a>'),
                   days=settings.VERIFY_STUDENT.get("EXPIRING_SOON_WINDOW")
                 )}
@@ -425,7 +425,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
                   <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
                 % else:
-                  <a class="action action-upgrade track_course_dashboard_green_button" href="${IDVerificationService.get_verify_location(course_id=course_overview.id)}" data-course-id="${course_overview.id}" data-user="${user.username}">
+                  <a class="action action-upgrade track_course_dashboard_green_button" href="${IDVerificationService.get_verify_location(url_name='verify_student_upgrade_and_verify', course_id=course_overview.id)}" data-course-id="${course_overview.id}" data-user="${user.username}">
                 % endif
                     <span class="action-upgrade-icon" aria-hidden="true"></span>
                   <span class="wrapper-copy">

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -14,7 +14,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
             %if verification_expiry:
                 <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo ID verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
                 <div class="btn-reverify">
-                    <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>
+                    <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
                 </div>
             %endif
         </li>
@@ -40,7 +40,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
             %endif
             </p>
         <div class="btn-reverify">
-            <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>
+            <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
         </div>
         </li>
     %elif verification_status == 'expired':
@@ -49,7 +49,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
             <p class="status-note">${_("Your ID verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
             <p class="status-note"><span><b>${_("Warning")}: </b></span>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</p>
             <div class="btn-reverify">
-                <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>
+                <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
             </div>
         </li>
     %endif

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -155,6 +155,7 @@ class CourseApiTestViews(BaseCoursewareTests, MasqueradeMixin):
                 else:
                     assert response.data['certificate_data']['cert_status'] == 'earned_but_not_available'
                     expected_verify_identity_url = IDVerificationService.get_verify_location(
+                        'verify_student_verify_now',
                         course_id=self.course.id
                     )
                     # The response contains an absolute URL so this is only checking the path of the final

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -239,9 +239,9 @@ class CoursewareMeta:
         if self.enrollment_object and self.enrollment_object.mode in CourseMode.VERIFIED_MODES:
             verification_status = IDVerificationService.user_status(self.effective_user)['status']
             if verification_status == 'must_reverify':
-                return IDVerificationService.get_verify_location()
+                return IDVerificationService.get_verify_location('verify_student_reverify')
             else:
-                return IDVerificationService.get_verify_location(self.course_key)
+                return IDVerificationService.get_verify_location('verify_student_verify_now', self.course_key)
 
     @property
     def verification_status(self):


### PR DESCRIPTION
## Description
Use the Django views for the Identity Verification Service instead of relying on the account MFE.

This is essentially a revert of: 
- 00ad36839d73e47a8f82dc5272222c150bda5e4e 
- 4d19d9687cd4366735967bd072fe077f2dc20969
- 2a4c26c3675076657806e5f228669bc5522f78cd

Previously performing the IDV via the account MFE was behind a waffle flag that was removed, I opted to use a new setting `ENABLE_ACCOUNT_MFE` instead of the original `redirect_to_idv_microfrontend` (which relies on the flag).

## Testing instructions
There are several ways to access the verification views, most notably the 'Verify Now' button that appears in the dashboard listing once you enroll in a course in a verified mode.

1. Create course with a verified mode.
2. Enroll in the course, make sure your enrollment type is the verified mode you chose (verified, professional)
3. Click on the 'Verify Now' link and perform the verification flow.

## Additional Info
The usual way to create a verified course is through the ecommerce service. Currently we don't have access to the ecommerce service, neither on stage or our tutor based development tools, so we have to take some manual steps.

1. To create course with a verified track, we create a new course and add two entries to the course modes table for said course: one for audit and one for verified.
2. We comment[ this call](https://github.com/eduNEXT/edunext-platform/blob/edunext/limonero.master/lms/djangoapps/verify_student/views.py#L398) to the ecommerce service and set `processors=""`