### PR TITLE
feat: Add token which disables different origin subframe

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4671,3 +4671,7 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+
+################# Settings for Chrome-specific origin trials ########
+# Token for " Disable Different Origin Subframe Dialog Suppression" for http://localhost:18000
+CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = 'ArNBN7d1AkvMhJTGWXlJ8td/AN4lOokzOnqKRNkTnLqaqx0HpfYvmx8JePPs/emKh6O5fckx14LeZIGJ1AQYjgAAAABzeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjE4MDAwIiwiZmVhdHVyZSI6IkRpc2FibGVEaWZmZXJlbnRPcmlnaW5TdWJmcmFtZURpYWxvZ1N1cHByZXNzaW9uIiwiZXhwaXJ5IjoxNjM5NTI2Mzk5fQ=='  # pylint: disable=line-too-long

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1048,3 +1048,9 @@ LOGO_IMAGE_EXTRA_TEXT = ENV_TOKENS.get('LOGO_IMAGE_EXTRA_TEXT', '')
 
 ############## XBlock extra mixins ############################
 XBLOCK_MIXINS += tuple(XBLOCK_EXTRA_MIXINS)
+
+################# Settings for Chrome-specific origin trials ########
+# Token for "Disable Different Origin Subframe Dialog Suppression" Chrome Origin Trial, which must be origin-specific.
+CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN = ENV_TOKENS.get(
+    'CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN', CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN
+)

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -34,6 +34,7 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="origin-trial" content="${settings.CHROME_DISABLE_SUBFRAME_DIALOG_SUPPRESSION_TOKEN}">
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
## Description

This PR is part of the changes that were made after the migration cut, but it is necessary for bragi to work in limonero.

- [Cherry-pick](https://github.com/eduNEXT/edx-platform/commit/d6077850a88eb3d823b0f628146c4e7ca0a6a246)

Issues that need this change to work in limonero:

- [JU-11 Bragi](https://edunext.atlassian.net/browse/PS2021-1266?atlOrigin=eyJpIjoiYTRlMThiMjJmYTMxNGI3OGI1YjI0Nzc5ZTVlYTg1MWYiLCJwIjoiaiJ9)
- [Bragi](https://edunext.atlassian.net/browse/PS2021-1264?atlOrigin=eyJpIjoiYmYzMWY1ZWUzY2U1NGFmNWI2MDY4YWVjMjRhOWQ2ZTgiLCJwIjoiaiJ9)


Without this change the bragi `main.html` causes this error to appear:
![Screenshot from 2021-11-26 16-33-39](https://user-images.githubusercontent.com/35668326/143662087-b99cefd5-9160-4f4f-bb86-52ba742cb253.png)