### PR TITLE
Li/ednx/li-7

### DIFF
--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -83,7 +83,7 @@ class CcxRestApiTest(CcxTestCase, APITestCase):
             user=user,
             client_type='confidential',
             authorization_grant_type='authorization-code',
-            redirect_uris='http://localhost:8079/complete/edxorg/'
+            redirect_uris='http://localhost:8079/complete/edxorg/ http://testserver/'
         )
         # create an authorization code
         auth_oauth2_provider = dot_models.AccessToken.objects.create(

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -959,6 +959,10 @@ DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+####################### ALLOWED APPLICATIONS####################
+#The applications in this list won't be restricted by site.
+ALLOWED_AUTH_APPLICATIONS = ENV_TOKENS.get('ALLOWED_AUTH_APPLICATIONS', [])
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
@@ -23,6 +23,7 @@ class ApplicationFactory(DjangoModelFactory):
     client_type = 'confidential'
     authorization_grant_type = Application.CLIENT_CONFIDENTIAL
     name = FuzzyText(prefix='name', length=8)
+    redirect_uris = 'http://testserver/'
 
 
 class ApplicationAccessFactory(DjangoModelFactory):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -30,7 +30,7 @@ class ClientCredentialsTest(mixins.AccessTokenMixin, TestCase):
             name='test dot application',
             user=self.user,
             authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-app-client-id',
         )
         scopes = ['read', 'write', 'email']

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -99,7 +99,7 @@ class CustomAuthorizationViewTestCase(TestCase):
         restricted_app = self.dot_adapter.create_confidential_client(
             name='test restricted dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-restricted-app-client-id',
         )
         models.RestrictedApplication.objects.create(application=restricted_app)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -89,7 +89,7 @@ class _DispatchingViewTestCase(TestCase):
         self.dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-app-client-id',
         )
 
@@ -103,7 +103,7 @@ class _DispatchingViewTestCase(TestCase):
         self.restricted_dot_app = self.dot_adapter.create_public_client(
             name='test restricted dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-restricted-app-client-id',
         )
         models.RestrictedApplication.objects.create(application=self.restricted_dot_app)
@@ -308,7 +308,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id=f'dot-app-client-id-{grant_type}',
             grant_type=grant_type,
         )
@@ -372,7 +372,7 @@ class TestAuthorizationView(_DispatchingViewTestCase):
         self.dot_app = self.dot_adapter.create_confidential_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='confidential-dot-app-client-id',
         )
         models.ApplicationAccess.objects.create(

--- a/openedx/core/djangoapps/user_authn/tests/utils.py
+++ b/openedx/core/djangoapps/user_authn/tests/utils.py
@@ -105,7 +105,7 @@ class AuthAndScopesTestMixin:
             user=dot_app_user,
             client_type='confidential',
             authorization_grant_type='authorization-code',
-            redirect_uris='http://localhost:8079/complete/edxorg/'
+            redirect_uris='http://localhost:8079/complete/edxorg/ http://testserver/'
         )
         return dot_models.AccessToken.objects.create(
             user=user,

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -74,7 +74,7 @@ class OAuth2AllowInActiveUsersTests(TestCase):  # lint-amnesty, pylint: disable=
             name='example',
             user=self.user,
             client_id='dot-client-id',
-            redirect_uri='https://example.edx/redirect',
+            redirect_uri='https://example.edx/redirect http://testserver/',
         )
         self.dot_access_token = dot_models.AccessToken.objects.create(
             user=self.user,
@@ -228,6 +228,29 @@ class BearerAuthenticationTests(OAuth2AllowInActiveUsersTests):  # lint-amnesty,
         # Since this is testing back to previous version, user should be set to true
         self.user.is_active = True
         self.user.save()
+
+    def test_post_invalid_site_token(self):
+        """This tests when the token belongs to an application with allowed uris different from the current url."""
+        dot_oauth2_client = self.dot_adapter.create_public_client(
+            name='client-example',
+            user=self.user,
+            client_id='client-dot-client-id',
+            redirect_uri='https://client.com/',
+        )
+        token = dot_models.AccessToken.objects.create(
+            user=self.user,
+            token='client-dot-access-token',
+            application=dot_oauth2_client,
+            expires=now() + timedelta(days=30),
+        )
+
+        response = self.post_with_bearer_token(self.OAUTH2_BASE_TESTING_URL, token=token)
+
+        self.check_error_codes(
+            response,
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            error_code=authentication.OAUTH2_TOKEN_ERROR_NONEXISTENT
+        )
 
 
 class OAuthDenyDisabledUsers(OAuth2AllowInActiveUsersTests):  # pylint: disable=test-inherits-tests


### PR DESCRIPTION
This PR allows token to be validated per site.

- [Jira](https://edunext.atlassian.net/browse/PS2021-1186?atlOrigin=eyJpIjoiZmYzYTNiOWZkNzA3NDQ4MjlmMzI3MGQ1YmM4NzZiYzYiLCJwIjoiaiJ9)
- [Documentation](https://docs.google.com/document/d/11mpYNDDLeLgXheiafrL-7aCbvdzooeVGhWF78_NesPU/edit#)

## How to test

Enter in django admin oauth2_provider/application/ (in limonero is: http://lms.limonero.edunext.link:8000/admin/oauth2_provider/application/ ), add an application or use one, for example:
![Screenshot from 2021-12-13 13-52-10](https://user-images.githubusercontent.com/35668326/145864270-8496a63c-b52d-43cb-807b-6e2e700d0627.png)

Then make a request for Bearer token:

Postman
![Screenshot from 2021-12-13 13-52-59](https://user-images.githubusercontent.com/35668326/145864285-246db5d6-050e-45d2-8154-26fd3e2ecc16.png)

Shell
```shell
curl --location --request POST 'http://tenant-a.lms.limonero.edunext.link:8000/oauth2/access_token' \
--header 'Cookie: openedx-language-preference=en' \
--form 'client_id="tenant-a-client-id"' \
--form 'client_secret="tenant-a-client-secret"' \
--form 'grant_type="client_credentials"'
```

Use that token in Authorization Bearer for API request

Postman
![Screenshot from 2021-12-13 13-54-05](https://user-images.githubusercontent.com/35668326/145864299-02bff1a2-8896-4c38-81b5-68b3109dc9f2.png)

Shell
```shell
curl --location --request GET 'http://tenant-a.lms.limonero.edunext.link:8000/eox-tagging/api/v1/tags/' \
--header 'Authorization: Bearer qzo1IJQYT1uXsvzc07prYMjfUYKXl2'
```



Try with other site:

Postman
![Screenshot from 2021-12-13 13-56-10](https://user-images.githubusercontent.com/35668326/145864309-954a63a1-5b50-4c3f-8b71-488ff9ca7ea3.png)

Shell
```shell
curl --location --request GET 'http://lms.limonero.edunext.link:8000/eox-tagging/api/v1/tags/' \
--header 'Authorization: Bearer qzo1IJQYT1uXsvzc07prYMjfUYKXl2'
```

Without LI-7 we can do API requests in other sites with one token.