### PR TITLE
JSB/LI-1

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4671,3 +4671,5 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+#################### DELETION TEXT ###########################
+SITE_SPECIFIC_DELETION_TEXT = ''

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -113,16 +113,8 @@ export class StudentAccountDeletion extends React.Component {
               <span>{bodyDeletion2}</span>
         </p>
         <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: loseAccessText }}
-        />
-        <p
           className="account-settings-header-subtitle-warning"
           dangerouslySetInnerHTML={{ __html: acctDeletionWarningText }}
-        />
-        <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: changeAcctInfoText }}
         />
         <Button
           id="delete-account-btn"

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -165,7 +165,6 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                         <span>{bodyDeletion} </span>
                         <span>{bodyDeletion2}</span>
                       </p>
-                      <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
**description:**
To maintain the eduNEXT brand when account deletion deleted some refs to openedx.

**commits migrated:**
- 533b360

**jira:**
- [issue](https://edunext.atlassian.net/browse/PS2021-1179)

**note:**
To test in local is important compile statics within tutor:
```bash
tutor dev run lms openedx-assets build --env=dev
```

**result:**
![Screenshot from 2021-12-13 11-26-17](https://user-images.githubusercontent.com/18581590/145851614-82c110eb-6dc8-4c36-b1ce-cedb107646a6.png)
![Screenshot from 2021-12-13 11-24-02](https://user-images.githubusercontent.com/18581590/145851616-3691a21e-71ec-4533-9673-7043626118ab.png)

**before:**
![majito1](https://user-images.githubusercontent.com/18581590/145851934-a9ed8c1d-9be4-45ff-bb27-46a591fa6458.png)
![majito](https://user-images.githubusercontent.com/18581590/145851936-4545fa41-18d3-4e38-b5b6-7cb3b0a3079f.png)
