### PR TITLE
feat: Register webhook_xblock tasks in celery

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2576,6 +2576,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+# Celery's task autodiscovery won't find tasks nested in a tasks package.
+# Tasks are only registered when the module they are defined in is imported.
+CELERY_IMPORTS = (
+    'webhook_xblock.tasks',
+)
+
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'


### PR DESCRIPTION
## _Description_

This PR configures the webhook-xblock to send notifications to external URLs when going through some predefined part of the course. 

## _Testing instructions_

1. Install webhook-xblock
` pip install git+https://github.com/eduNEXT/webhook-xblock@a734c6de47cb61cba20bec4a4f3362ce625d47d1#egg=webhook-xblock==0.2.0_1` 
2. Go to Studio and configure the xblock in your course
- Navigate to Settings -> Advanced Settings and go to the Advanced Module List setting.
- To enable the XBlock for your course, add "webhook-xblock" to the list and save the changes.
- In the course configure the Advanced (for example in a unit) 
3. You need to have a test webhook 
<https://webhook.site>
4. Enter the course and go to the unit where the advanced was configured 
5. Expected result in the test webhook 
![Screenshot from 2021-12-14 17-32-08](https://user-images.githubusercontent.com/93566377/146118545-b81011f0-5597-46c8-af6d-1ec3d37b0d7a.png)
## Other information
Since xblock-poll is not a Django app, and XBlocks don't get auto-imported by celery workers, its tasks will not get auto-discovered
