### PR TITLE
Fix to prevent 500 error when course mode currency is not the same as…

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -762,7 +762,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        return min(
+            (mode.min_price for mode in modes if mode.currency.lower() == currency.lower()),
+            default=0
+        )
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):


### PR DESCRIPTION
**Background:**
This PR solves the http 500 error because of the `CURRENCY PAID MODE` is setted different `USD` the currency default in the django settings and the course created is another one.

**Commits:**
- 38959ca
**Jira:**
- https://edunext.atlassian.net/browse/PS2021-1165

**After:**
![Screenshot from 2021-12-17 10-52-37](https://user-images.githubusercontent.com/18581590/146572057-3802e8ce-5f06-4bcf-8d87-a4c70e30f656.png)

**Before:**
![Screenshot from 2021-12-17 10-54-43](https://user-images.githubusercontent.com/18581590/146572093-4fc9eb8e-6de4-481e-b70c-30a2204b66db.png)

