### PR TITLE
Li/ednx/li 4

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -308,10 +308,15 @@ def load_metadata_from_youtube(video_id, request):
     Get metadata about a YouTube video.
 
     This method is used via the standalone /courses/yt_video_metadata REST API
-    endpoint, or via the video XBlock as a its 'yt_video_metadata' handler.
+    endpoint, or via the video XBlock as a its 'yt_video_metadata' handler. sd
     """
-    metadata = {}
+    cache_key = f'yt_video_metadata_cache.{video_id}'
+    metadata = cache.get(cache_key, {})
     status_code = 500
+
+    if metadata:
+        return metadata, 200
+
     if video_id and settings.YOUTUBE_API_KEY and settings.YOUTUBE_API_KEY != 'PUT_YOUR_API_KEY_HERE':
         yt_api_key = settings.YOUTUBE_API_KEY
         yt_metadata_url = settings.YOUTUBE['METADATA_URL']
@@ -340,6 +345,11 @@ def load_metadata_from_youtube(video_id, request):
                     res_json = res.json()
                     if res_json.get('items', []):
                         metadata = res_json
+                        cache.set(
+                            cache_key,
+                            metadata,
+                            getattr(settings, 'YT_VIDEO_METADATA_CACHE_TIMEOUT', 3600 * 24 * 7),
+                        )
                     else:
                         logging.warning('Unable to find the items in response. Following response '
                                         'was received: {res}'.format(res=res.text))


### PR DESCRIPTION
## _Description_
This PR increases the duration of the cache by 7 days, in this way the consumption of the YouTube metadata API is not always carried out, which has a limit of 10 thousand calls per day.
## _Supporting information_
[Cache the response from the youtube video metadata view ][ed1]

[ed1]: <https://github.com/eduNEXT/edunext-platform/commit/12c632760f70fc3ed6c3bff3c3550573946272c3>
## _Testing instruction_
1. Configure YouTube API key
```` YOUTUBE_API_KEY = 'your-api-key' ````
2. Use a breakpoint to validate cache setting
``` import pudb;pu.db ```
3. Results:
As you can see in the image, the cache was configured correctly
![Screenshot from 2021-12-17 08-30-21](https://user-images.githubusercontent.com/93566377/146572571-43451cc9-2c2b-422f-9755-01d360cdefa2.png)
![Screenshot from 2021-12-17 08-33-01](https://user-images.githubusercontent.com/93566377/146572598-21c8b4ea-088c-49d1-8ce8-e6798bf6a5b9.png)

## _Other information_
[To create your own API KEY][key]

[key]: <https://blog.hubspot.com/website/how-to-get-youtube-api-key>