### PR TITLE
fix: LI-10, improve home studio performance.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -32,6 +32,7 @@ from common.djangoapps.student.roles import (
     UserBasedRole
 )
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from xmodule.course_module import CourseSummary
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -315,30 +316,41 @@ class TestCourseListing(ModuleStoreTestCase):
         all of them.
         """
         org_course_one = self.store.make_course_key('AwesomeOrg', 'Course1', 'RunBabyRun')
-        CourseFactory.create(
+        course_1 = CourseFactory.create(
             org=org_course_one.org,
             number=org_course_one.course,
             run=org_course_one.run
         )
+        CourseOverviewFactory.create(id=course_1.id, org='AwesomeOrg')
 
         org_course_two = self.store.make_course_key('AwesomeOrg', 'Course2', 'RunBabyRun')
-        CourseFactory.create(
+        course_2 = CourseFactory.create(
             org=org_course_two.org,
             number=org_course_two.course,
             run=org_course_two.run
         )
+        CourseOverviewFactory.create(id=course_2.id, org='AwesomeOrg')
 
         # Two types of org-wide roles have edit permissions: staff and instructor.  We test both
         role.add_users(self.user)
 
-        with self.assertRaises(AccessListFallback):
-            _accessible_courses_list_from_groups(self.request)
         courses_list, __ = get_courses_accessible_to_user(self.request)
 
         # Verify fetched accessible courses list is a list of CourseSummery instances and test expacted
         # course count is returned
         self.assertEqual(len(list(courses_list)), 2)
         self.assertTrue(all(isinstance(course, CourseSummary) for course in courses_list))
+
+    @ddt.data(OrgStaffRole(), OrgInstructorRole())
+    def test_course_listing_org_permissions_exception(self, role):
+        """
+        Create roles with no course_id neither org to make sure AccessListFallback is raised for
+        platform-wide permissions
+        """
+        role.add_users(self.user)
+
+        with self.assertRaises(AccessListFallback):
+            _accessible_courses_list_from_groups(self.request)
 
     def test_course_listing_with_actions_in_progress(self):
         sourse_course_key = CourseLocator('source-Org', 'source-Course', 'source-Run')

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -483,10 +483,20 @@ def _accessible_courses_list_from_groups(request):
     courses_list = []
     course_keys = {}
 
+    user_global_orgs = set()
     for course_access in all_courses:
-        if course_access.course_id is None:
+        if course_access.course_id is not None:
+            course_keys[course_access.course_id] = course_access.course_id
+        elif course_access.org:
+            user_global_orgs.add(course_access.org)
+        else:
             raise AccessListFallback
-        course_keys[course_access.course_id] = course_access.course_id
+
+    if user_global_orgs:
+        # Getting courses from user global orgs
+        overviews = CourseOverview.get_all_courses(orgs=list(user_global_orgs))
+        overviews_course_keys = {overview.id: overview.id for overview in overviews}
+        course_keys.update(overviews_course_keys)
 
     course_keys = list(course_keys.values())
 


### PR DESCRIPTION
# Increase performance in course home_page.

## Description
Improving Studio homepage performance for users with course access role with no course_id.

Fixing unit tests

Added create CourseOverviewFactory after creating a course to course listing test.

## Process

This PR has two possible issues to improve the home page load for the studio: The wafer switch and the Jhonny PR.
I have tested both and the best solution for the home page `home `was the wafer switch, otherwise, the Jhony PR  https://github.com/eduNEXT/edunext-platform/pull/501 helps with other pages like  `/settings/details/<course_id> `.

### Waffer switch
The wafer switch avoids loading all courses of the studio page if you are an admin or staff user, so you have to search in other to use a specific course.
Also, the response using this feature has a good increase in performance. (From 1 min to 2 s.)
This waffer flag is discussed here: https://3.basecamp.com/3966315/buckets/7099599/messages/4111327402
![waffer_switch_studio](https://user-images.githubusercontent.com/51926076/147252794-5feaf78c-f706-4432-92d9-188424aedf2c.png)


**before:**
![without_waffer_switch2](https://user-images.githubusercontent.com/51926076/147252725-b00f7dd3-451b-4c6c-9354-c6e4846a2029.png)

**after**:

![with_waffer_switch2](https://user-images.githubusercontent.com/51926076/147252968-1d9a98eb-95de-4f84-bfe2-62b3ea6eacdc.png)

###  Jhony PR: 

**_accessible_courses_list_from_groups**
This PR attempts to improve the performance of a global instructor or staff-admin permission, but in this part 
with this kind of user, the flow always uses the slower function and not the improvement calling `_accessible_courses_summary_iter`. 

https://github.com/eduNEXT/edunext-platform/blob/1b8d75b9af22667259858e7a5ffe7f1b0624cee5/cms/djangoapps/contentstore/views/course.py#L755-L765

Otherwise for local or staff instructors of a specific org should be fixed calling `_accessible_courses_list_from_groups1`.
![course-staff-local-role](https://user-images.githubusercontent.com/51926076/147507906-fbe5d821-9b5e-4b66-aa38-451dc766e37d.png)


 Even a course doesn't have an id, adding the id if possible:
https://github.com/eduNEXT/edunext-platform/blob/64d366185b069d950be00188643c4c279dd32d6c/cms/djangoapps/contentstore/views/course.py#L487-L493
 In that way not raising immediately the assertion ` AccessListFallback` calling the slower one   `_accessible_courses_summary_iter`.

In this case, the PR helps to improve the performance avoiding the slower method of searching a particular org. In this case, passing from 12s to 3 s.

**before:**
![staff-without-change](https://user-images.githubusercontent.com/51926076/147507997-3c5f6e02-acda-41a1-929b-c5124456ccad.png)

**After**
![after-staff-local](https://user-images.githubusercontent.com/51926076/147508009-b9239d16-4240-4120-b8df-14ce79131f27.png)


**extra**: 
- (cherry picked from commit 199d9a9f6e597ce2f19775621f9262dc5fd13173)
- Jira: 
## Checklist for Merge
- [x] Tested in local environment: stackbuilder  limonero local.
- [x] Tested in a remote environment: lilac stage
- [x] Rebased limonero.master
- [x] Squashed commits