### PR TITLE
chore: LI 12, relax load in instructor dashboard page..

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -112,7 +112,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         log.error("Unable to find course with course key %s while loading the Instructor Dashboard.", course_id)
         return HttpResponseServerError()
 
-    course = get_course_by_id(course_key, depth=0)
+    course = get_course_by_id(course_key, depth=None)
 
     access = {
         'admin': request.user.is_staff,


### PR DESCRIPTION
# Relax load in instructor dashboard.

## Description
Fix: Relax load on the instructor dashboard page.

This PR is based on the implementation of Jhony.
https://github.com/eduNEXT/edunext-platform/pull/519



Bringing all the course children when fetching a course in the instructor dashboard page.

## Process

This PR was tested in limonero-local with stack builder, but the purpose to test the instructor dashboard lag couldn't be replicated due to the dimension of the mongo local courses. 

For that reason, this PR was tested in stage lilac.
Also, it was necessary to find a big course thinking that the Jhony PR https://github.com/eduNEXT/edunext-platform/pull/519 says that the problem is searching with the block or subsections with due date. For that reason I make a mongo query in mongo shell to find the course structure with more due dates. 

```mongo 
use edxapp

db.modulestore.structures.aggregate([
    {"$match":{"root.0":"course"}},
    { "$project": {
      "dueBlocks": {
        "$size": {
          "$filter": {
            "input": "$blocks",
            "as": "bot",
            "cond": { "$gt": ["$$bot.fields.due", null] }
            }
          }
        }
      }
    },
    {"$sort": { "dueBlocks": -1 }},
    {"$limit": 5}
  ])
```
This returns the id structure and the quantity of due blocks.

```
{ _id: ObjectId("61b8d306545ca25b9e3ddcc1"), dueBlocks: 232 }
{ _id: ObjectId("61b9b944012990ee9ba10eea"), dueBlocks: 232 }
```
Then in `edxapp.modulestore.active_versions` continue and find the course of the id structure. 
`{"versions.published-branch": ObjectId('61b9b944012990ee9ba10eea')}`

With the course, I tested the time response as a client of the page `/instructor#view-course_info` before and after the change. This change increases the performance of response from 13s to 3s of time.

**before**:
![bracu-13s](https://user-images.githubusercontent.com/51926076/147491742-c97b9fd8-b66b-4f4e-80b1-3ff1876d2b06.png)

**after**
![bracu-3s](https://user-images.githubusercontent.com/51926076/147491747-843bf485-5c59-402d-adef-593241d3e681.png)

**note**: Probably it wasn't necessarily a course with a lot of due dates, but with a lot of subsections or children in order to test the lag.


**extra**: 
- (cherry picked from commit f3d2c42fc02a684eb057ec55b0945511326640af)
- Jira: 
https://edunext.atlassian.net/browse/PS2021-1189?atlOrigin=eyJpIjoiYWQxZGY5M2ZjMjJjNDMzOTg3OTRlM2RmOGE0MGRmNTYiLCJwIjoiaiJ9

## Checklist for Merge
- [x] Tested in local environment: stackbuilder  limonero local.
- [x] Tested in a remote environment: lilac stage
- [x] Rebased limonero.master
- [x] Squashed commits