### PR TITLE
FFI-8 P3: Fix python package installation

### DIFF
--- a/.github/workflows/cms-tests.yml
+++ b/.github/workflows/cms-tests.yml
@@ -36,10 +36,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/common_tests_01.yml
+++ b/.github/workflows/common_tests_01.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/common_tests_02.yml
+++ b/.github/workflows/common_tests_02.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -35,10 +35,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/lms-tests.yml
+++ b/.github/workflows/lms-tests.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -40,10 +40,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_01.yml
+++ b/.github/workflows/openedx_tests_01.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -36,10 +36,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_02.yml
+++ b/.github/workflows/openedx_tests_02.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -36,10 +36,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_03.yml
+++ b/.github/workflows/openedx_tests_03.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -37,10 +37,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_04.yml
+++ b/.github/workflows/openedx_tests_04.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -36,10 +36,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_05.yml
+++ b/.github/workflows/openedx_tests_05.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -35,10 +35,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_06.yml
+++ b/.github/workflows/openedx_tests_06.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -36,10 +36,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
 
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/openedx_tests_07.yml
+++ b/.github/workflows/openedx_tests_07.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   run-tests:
-    continue-on-error: true
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.8']
         django-version: ["2.2"]
@@ -38,10 +38,10 @@ jobs:
 
       - name: Install requirements
         run: |
-          sudo pip install --ignore-installed -r requirements/pip.txt
-          sudo pip install --ignore-installed -r requirements/edx/testing.txt
-          sudo pip install --exists-action w -r requirements/edunext/base.txt
-          sudo pip install "django~=${{ matrix.django-version }}.24"
+          pip install --upgrade --force-reinstall -r requirements/pip.txt
+          pip install --upgrade --force-reinstall -r requirements/edx/testing.txt
+          pip install --exists-action w -r requirements/edunext/base.txt
+          pip install "django~=${{ matrix.django-version }}.24"
       
       - name: Run tests
         uses: nick-invision/retry@v2

--- a/.github/workflows/pylint-checks.yml
+++ b/.github/workflows/pylint-checks.yml
@@ -41,12 +41,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/edx/development.txt') }}-${{ hashFiles('requirements/edunext/base.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
     - name: Install Required Python Dependencies
       run: |
         pip install -r requirements/pip.txt
+        pip install -r requirements/edunext/base.txt --src ${{ runner.temp }}
         pip install -r requirements/edx/development.txt --src ${{ runner.temp }}
 
     - name: Run Quality Tests


### PR DESCRIPTION
## Description
- Ensure the correct dependencies are installed even with a broken version in the cache.
- Move from `continue-on-error: true` to `fail-fast: false` to avoid green checks even when all jobs failed.
- Install eduNEXT dependencies on the pylint workflows. There was an import error due to eox-tenant that broke the pylint run. Because pylint is run via paver the exit code is 0 when an error is found and the result of the job was a success. This pylint violations seem to have been silenced for a few weeks now.