### PR TITLE
FFI-8 P4: fix pylint failures

### DIFF
--- a/cms/djangoapps/contentstore/views/organization.py
+++ b/cms/djangoapps/contentstore/views/organization.py
@@ -5,7 +5,6 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import View
-from organizations.api import get_organizations
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1451,7 +1451,7 @@ class CourseEnrollment(models.Model):
                         pii=UserPersonalData(
                             username=self.user.username,
                             email=self.user.email,
-                            name=self.user.profile.name,
+                            name=self.user.profile.name,  # pylint: disable=no-member
                         ),
                         id=self.user.id,
                         is_active=self.user.is_active,
@@ -1477,7 +1477,7 @@ class CourseEnrollment(models.Model):
                             pii=UserPersonalData(
                                 username=self.user.username,
                                 email=self.user.email,
-                                name=self.user.profile.name,
+                                name=self.user.profile.name,  # pylint: disable=no-member
                             ),
                             id=self.user.id,
                             is_active=self.user.is_active,
@@ -1683,7 +1683,7 @@ class CourseEnrollment(models.Model):
                     pii=UserPersonalData(
                         username=user.username,
                         email=user.email,
-                        name=user.profile.name,
+                        name=user.profile.name,  # pylint: disable=no-member
                     ),
                     id=user.id,
                     is_active=user.is_active,

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -10,10 +10,6 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from django_countries.fields import Country
 
-from common.djangoapps.student.models import CourseEnrollmentAllowed, CourseEnrollment
-from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory, UserProfileFactory
-from common.djangoapps.student.tests.tests import UserSettingsEventTestMixin
-
 from openedx_events.learning.data import (
     CourseData,
     CourseEnrollmentData,
@@ -26,8 +22,11 @@ from openedx_events.learning.signals import (
     COURSE_UNENROLLMENT_COMPLETED,
 )
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
-from openedx.core.djangolib.testing.utils import skip_unless_lms
 
+from common.djangoapps.student.models import CourseEnrollmentAllowed, CourseEnrollment
+from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory, UserProfileFactory
+from common.djangoapps.student.tests.tests import UserSettingsEventTestMixin
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -1,18 +1,17 @@
 """
 Test that various filters are fired for models in the student app.
 """
+from django.test import override_settings
+from openedx_filters.learning.enrollment import PreEnrollmentFilter
+from openedx_filters import PipelineStep
+
 from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from django.test import TestCase, override_settings
-from openedx_filters.learning.enrollment import PreEnrollmentFilter
-
 
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-
-from openedx_filters import PipelineStep
 
 
 class TestEnrollmentPipelineStep(PipelineStep):
@@ -20,7 +19,7 @@ class TestEnrollmentPipelineStep(PipelineStep):
     Utility function used when getting steps for pipeline.
     """
 
-    def run(self, user, course_key, mode):
+    def run(self, user, course_key, mode):  # pylint: disable=unused-argument, arguments-differ
         """Pipeline steps that changes mode to honor."""
         if mode == "no-id-professional":
             raise PreEnrollmentFilter.PreventEnrollment()

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -23,6 +23,8 @@ from model_utils.fields import AutoCreatedField
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
 from simple_history.models import HistoricalRecords
+from openedx_events.learning.data import CourseData, UserData, UserPersonalData, CertificateData
+from openedx_events.learning.signals import CERTIFICATE_CHANGED, CERTIFICATE_CREATED, CERTIFICATE_REVOKED
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
@@ -33,8 +35,6 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED, COURSE_CERT_CHANGED, COURSE_CERT_REVOKED
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 
-from openedx_events.learning.data import CourseData, UserData, UserPersonalData, CertificateData
-from openedx_events.learning.signals import CERTIFICATE_CHANGED, CERTIFICATE_CREATED, CERTIFICATE_REVOKED
 
 log = logging.getLogger(__name__)
 User = get_user_model()

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -5,7 +5,6 @@ Unit tests for course_goals.api methods.
 
 from unittest import mock
 
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -13,11 +13,11 @@ from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from opaque_keys.edx.django.models import CourseKeyField
+from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
 
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
-from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
-from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
 
 log = logging.getLogger(__name__)
 
@@ -139,7 +139,7 @@ class CohortMembership(models.Model):
                     pii=UserPersonalData(
                         username=self.user.username,
                         email=self.user.email,
-                        name=self.user.profile.name,
+                        name=self.user.profile.name,  # pylint: disable=no-member
                     ),
                     id=self.user.id,
                     is_active=self.user.is_active,

--- a/openedx/core/djangoapps/course_groups/tests/test_events.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_events.py
@@ -4,19 +4,16 @@ Test classes for the events sent in the cohort assignment process.
 Classes:
     CohortEventTest: Test event sent after cohort membership changes.
 """
-from openedx.core.djangoapps.course_groups.models import CohortMembership
 from unittest.mock import Mock
-
 from openedx_events.learning.data import CohortData, CourseData, UserData, UserPersonalData
 from openedx_events.learning.signals import COHORT_MEMBERSHIP_CHANGED
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
 
+from openedx.core.djangoapps.course_groups.models import CohortMembership
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -87,7 +87,7 @@ class EdxOAuth2Validator(OAuth2Validator):
             #       Without this modification the BearerToken class will set this to 3600
             request.expires_in = getattr(settings, 'CLIENT_CREDENTIALS_ACCESS_TOKEN_EXPIRE_SECONDS', 31557600)
 
-        super(EdxOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
+        super().save_bearer_token(token, request, *args, **kwargs)
 
         is_restricted_client = self._update_token_expiry_if_restricted_client(token, request.client)
         if not is_restricted_client:

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -253,7 +253,7 @@ def create_account_with_params(request, params):
             pii=UserPersonalData(
                 username=user.username,
                 email=user.email,
-                name=user.profile.name,
+                name=user.profile.name,  # pylint: disable=no-member
             ),
             id=user.id,
             is_active=user.is_active,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -20,8 +20,8 @@ from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from freezegun import freeze_time
-from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
 from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from common.djangoapps.student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
 
 from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordException,


### PR DESCRIPTION
### Description
This PR fixes some pylint violations made during the course of the lilac migration. They didn't appear on the error logs because of a github actions configuration explained better here: https://github.com/eduNEXT/edunext-platform/pull/606

### Some context

The platform at the lilac cut had a few quality errors that in edx-platform@master were already solved. So then, we had two options, backport those fixes -a big no, more changes to support- or ignore them completely and fix new violations introduced by our changes. To ignore them, we counted the total of pylint violations in the lilac release and used the number as our threshold. So, for example, if the admitted pylint violations for the common app were 30, then when adding a change that introduces another violation, pylint checks will fail. That's the point.

Unfortunately, for the reason explained above, we missed approx. 15 violations -**IMPORTANT**: These were introduced by our changes- which we're fixing with this PR.

For the next migration: the ideal situation is fixing these style issues when introducing the changes, not after.