### PR TITLE
LI-14 revert: removing read_committed argument from outer_atomic function

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -238,7 +238,7 @@ class ChooseModeView(View):
 
     @method_decorator(transaction.non_atomic_requests)
     @method_decorator(login_required)
-    @method_decorator(outer_atomic(read_committed=True))
+    @method_decorator(outer_atomic())
     def post(self, request, course_id):
         """Takes the form submission from the page and parses it.
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -256,7 +256,7 @@ def _update_email_opt_in(request, org):
 
 @transaction.non_atomic_requests
 @require_POST
-@outer_atomic(read_committed=True)
+@outer_atomic()
 def change_enrollment(request, check_access=True):
     """
     Modify the enrollment status for the logged-in user.

--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -1,15 +1,12 @@
 """Tests for util.db module."""
 
 
-import threading
-import time
 import unittest
 from io import StringIO
 
 import ddt
-from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.management import call_command
-from django.db import IntegrityError, connection
+from django.db import connection
 from django.db.transaction import TransactionManagementError, atomic
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
@@ -22,7 +19,6 @@ def do_nothing():
     return
 
 
-@ddt.ddt
 class TransactionManagersTestCase(TransactionTestCase):
     """
     Tests outer_atomic.
@@ -31,65 +27,6 @@ class TransactionManagersTestCase(TransactionTestCase):
 
     To test do: "./manage.py lms --settings=test_with_mysql test util.tests.test_db"
     """
-    DECORATORS = {
-        'outer_atomic': outer_atomic(),
-        'outer_atomic_read_committed': outer_atomic(read_committed=True),
-    }
-
-    @ddt.data(
-        ('outer_atomic', IntegrityError, None, True),
-        ('outer_atomic_read_committed', type(None), False, True),
-    )
-    @ddt.unpack
-    def test_concurrent_requests(self, transaction_decorator_name, exception_class, created_in_1, created_in_2):
-        """
-        Test that when isolation level is set to READ COMMITTED get_or_create()
-        for the same row in concurrent requests does not raise an IntegrityError.
-        """
-        transaction_decorator = self.DECORATORS[transaction_decorator_name]
-        if connection.vendor != 'mysql':
-            raise unittest.SkipTest('Only works on MySQL.')
-
-        class RequestThread(threading.Thread):
-            """ A thread which runs a dummy view."""
-            def __init__(self, delay, **kwargs):
-                super().__init__(**kwargs)
-                self.delay = delay
-                self.status = {}
-
-            @transaction_decorator
-            def run(self):
-                """A dummy view."""
-                try:
-                    try:
-                        User.objects.get(username='student', email='student@edx.org')
-                    except User.DoesNotExist:
-                        pass
-                    else:
-                        raise AssertionError('Did not raise User.DoesNotExist.')
-
-                    if self.delay > 0:
-                        time.sleep(self.delay)
-
-                    __, created = User.objects.get_or_create(username='student', email='student@edx.org')
-                except Exception as exception:  # pylint: disable=broad-except
-                    self.status['exception'] = exception
-                else:
-                    self.status['created'] = created
-
-        thread1 = RequestThread(delay=1)
-        thread2 = RequestThread(delay=0)
-
-        thread1.start()
-        thread2.start()
-        thread2.join()
-        thread1.join()
-
-        assert isinstance(thread1.status.get('exception'), exception_class)
-        assert thread1.status.get('created') == created_in_1
-
-        assert thread2.status.get('exception') is None
-        assert thread2.status.get('created') == created_in_2
 
     def test_outer_atomic_nesting(self):
         """

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -815,7 +815,7 @@ class SubmitPhotosView(View):
         return super().dispatch(request, *args, **kwargs)
 
     @method_decorator(login_required)
-    @method_decorator(outer_atomic(read_committed=True))
+    @method_decorator(outer_atomic())
     def post(self, request):
         """
         Submit photos for verification.

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -207,7 +207,7 @@ def create_account_with_params(request, params):
     custom_form = get_registration_extension_form(data=params)
 
     # Perform operations within a transaction that are critical to account creation
-    with outer_atomic(read_committed=True):
+    with outer_atomic():
         # first, create the account
         (user, profile, registration) = do_create_account(form, custom_form)
 


### PR DESCRIPTION
## Description

In the PR https://github.com/edx/edx-platform/pull/10659 the outer_atomic decorator/context manager was created to prevent nested atomic blocks. This method received a boolean parameter read_committed to enforce read-committed MySQL isolation level. From Django 2, the default isolation level Django sets is read-committed, so the aforementioned parameter for outer_atomic can be removed.

[Jira](https://edunext.atlassian.net/browse/PS2021-1275?atlOrigin=eyJpIjoiNWZiNmZkZjllYjFiNGJlMWFjZjc4MDU3ZmJiMTU5NmEiLCJwIjoiaiJ9)
Juniper #537 
[Upstream PR](https://github.com/edx/edx-platform/pull/28161)

## How to test

This test only eliminates code that is no longer necessary, therefore it is necessary to verify that nothing is broken.

- Try to register user
- Try to change enrollments (already tested in test file https://github.com/eduNEXT/edunext-platform/blob/li/ednx/li-14/common/djangoapps/student/management/tests/test_change_enrollment.py )

**Other test:**
These two verifications could not be done in full but I got the same result with and without the change

- Try to do a post request in course_mode (POST http://lms.limonero.edunext.link:8000/course_modes/choose/course-v1:edX+DemoX+Demo_Course/ )

```bash
curl --location --request POST 'http://lms.limonero.edunext.link:8000/course_modes/choose/course-v1:edX+DemoX+Demo_Course/' \
--header 'Cookie: <your cookies>' \
--user username:password
```
I had an error with the csrf

- Try to verify student
http://lms.limonero.edunext.link:8000/verify_student/verify-now/course-v1:edX+DemoX+Demo_Course/
![Screenshot from 2021-12-28 09-40-02](https://user-images.githubusercontent.com/35668326/147572349-dbe778ea-9d5b-474f-ab62-e6886a3d32d6.png)

