### PR TITLE
JU-4: Studio performance fixes

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -593,11 +593,14 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    lms_root = configuration_helpers.get_value_for_org(
-        location.org,
-        'LMS_ROOT_URL',
-        settings.LMS_ROOT_URL
-    )
+    if getattr(settings, "EDNX_ENABLE_FIXED_LMS_ROOT", False):
+        lms_root = "https://openedx.edunext.co"
+    else:
+        lms_root = configuration_helpers.get_value_for_org(
+            location.org,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
     external_url = urljoin(lms_root, asset_url)
     return {
         'display_name': display_name,


### PR DESCRIPTION
### Description

This PR makes some performance fixes to studio application flow:

1. When creating assets external URL(s) in Studio's Files & Uploads
2. When uploading assets into a course
3. When jumping from Studio course preview to the LMS
4. When a superuser lists courses
5. When loading Date and About pages in studio

### How to test
1. When creating assets external URL(s) in Studio's Files & Uploads
First, go into courses Files & Uploads pages (Studio Course page > Content > Files & Uploads). Then, copy the external URL from an asset. It must have the LMS URL and the asset ID.
**Operation:** ` GET https://studio.le.edunextstage.net/assets/course-v1:testing-site+TS+01/ `

2. When uploading assets into a course
Now, upload an asset and repeat 1. 
**Operation:** `POST https://studio.le.edunextstage.net/assets/course-v1:testing-site+TS+01/`

3. When jumping from Studio course preview to the LMS (NOT WORKING. returns 404 not found. Besides, it's not being used for any of our sites)
First, turn on the `"EDNX_ENABLE_INTERNAL_LMS_JUMP" true,` setting in your studio site. Then, in the Content > Course Outline, click View Live. You must be redirected to your course in the LMS.

4. When a superuser lists courses
Go to Studio /home.
**Operation:** `GET https://studio.le.edunextstage.net/home`

5. When loading Date and About pages in Studio
Turn on: `EDNX_ENABLE_FIXED_SETTINGS_VALUES_ORG_STUDIO` in your Studio site settings. Then, go to Settings > Schedule & Details
**Operation:** `GET https://studio.le.edunextstage.net/settings/details/course-v1:testing-site+TS+01`

### Performance improvements
Using [this](https://github.com/black-redoc/benchmark_script) script to calculate the benchmark (thank you @black-redoc). After 100 runs each:
<table>
    <thead>
        <tr>
            <th></th>
            <th>Before changes</th>
            <th>After changes</th>
            <th>Improvement</th>
        </tr>
    </thead>
    <tbody>
<tr>
            <td>Step 1</td>
            <td>1.08s</td>
            <td>0.82s</td>
            <td>24%</td>
        </tr>
        <tr>
            <td>Step 2</td>
            <td>1.45s</td>
            <td>0.94s</td>
            <td>35%</td>
        </tr>
        <tr>
            <td>Step 4</td>
            <td>4.16s</td>
            <td>2.17s</td>
            <td>48%</td>
        </tr>
        <tr>
            <td>Step 5</td>
            <td>38.58s</td>
            <td>33.86s</td>
            <td>12%</td>
        </tr>
    </tbody>
</table>