### PR TITLE
fix: JU-7,grading for sga  in persistence way.

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -271,7 +271,6 @@ def _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs):
                 "student_id": kwargs['anonymous_user_id'],
                 "course_id": str(scored_block_usage_key.course_key),
                 "item_id": str(scored_block_usage_key),
-                "item_type": scored_block_usage_key.block_type,
             }
         )
         found_modified_time = score['created_at'] if score is not None else None


### PR DESCRIPTION
# Fix sga grading in persist notes.

grading from Staff Graded Assignment xblocks are not successfully being passed

block_type isn't guarantee to be the same as item_type. In this case, item_id should be enough for filtering.

Ticket [AU-70]


## Process
This PR is based on an old issue that doesn't allow to save the notes from sga block in a persistent way https://discuss.openedx.org/t/problems-with-sga-grade-submission/2415/3. 
Here there was the PR where was solved https://github.com/eduNEXT/edunext-platform/pull/447 , other way edx platform allows a new solution. In this case, we are taking the new solution of the edx-platform upstream PR https://github.com/edx/edx-platform/pull/28468.

Tested in local limonero environmet. The DatabaseNotReadyError no longer appears and the subsection grades of sga are updated successfully.

 ```
lms_1               | Traceback (most recent call last):
lms_1               |   File "/openedx/venv/lib/python3.8/site-packages/celery/app/trace.py", line 412, in trace_task
lms_1               |     R = retval = fun(*args, **kwargs)
lms_1               |   File "/openedx/venv/lib/python3.8/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 179, in new_function
lms_1               |     return wrapped_function(*args, **kwargs)
lms_1               |   File "/openedx/edx-platform/lms/djangoapps/grades/tasks.py", line 187, in recalculate_subsection_grade_v3
lms_1               |     _recalculate_subsection_grade(self, **kwargs)
lms_1               |   File "/openedx/edx-platform/lms/djangoapps/grades/tasks.py", line 256, in _recalculate_subsection_grade
lms_1               |     raise self.retry(kwargs=kwargs, exc=exc)
lms_1               |   File "/openedx/venv/lib/python3.8/site-packages/celery/app/task.py", line 706, in retry
lms_1               |     raise_with_context(exc)
lms_1               |   File "/openedx/edx-platform/lms/djangoapps/grades/tasks.py", line 239, in _recalculate_subsection_grade
lms_1               |     raise DatabaseNotReadyError
lms_1               | lms.djangoapps.grades.exceptions.DatabaseNotReadyError
lms_1               | 2021-12-30 14:03:47,327 INFO 125 [celery_utils.logged_task] [user 3] [ip 172.21.0.1] logged_task.py:25 - Task lms.djangoapps.grades.tasks.recalculate_subsection_grade_v3[713eb05e-a65f-43fb-bc6b-6b67adbd7377] submitted with arguments None, {'user_id': 10, 'anonymous_user_id': 'e4f28ffcdf338971bd394e5129829ad1', 'course_id': 'course-v1:testing-org+cd102+2021-t9', 'usage_id': 'block-v1:testing-org+cd102+2021-t9+type@edx_sga+block@f21ce0df3b46426d8614a518837c28f6', 'only_if_higher': None, 'expected_modified_time': 1640873026, 'score_deleted': False, 'event_transaction_id': 'd3fac6cf-62ce-46ac-b6d1-c551a4e6fd0e', 'event_transaction_type': 'edx.grades.problem.submitted', 'score_db_table': 'submissions', 'force_update_subsections': False}
```
## How to test

To test in limonero local environment you have to:
- Change to the branch `li/ednx/JU-7`.
- Enable the persistent grades in `/admin/grades/persistentgradesenabledflag/ `
![flag](https://user-images.githubusercontent.com/51926076/147788550-ceedc360-fc7e-45d1-a8d9-54991b37be55.png)
- Create a course to grade with sga or grading problems. You can use this: https://drive.google.com/file/d/1iGP3I3ojiaO6t7hkVV4k7zhmE0F6hDGa/view?usp=sharing
- Create a student user and submit or aproves some subsections of the course.
- Check that the subsection where graded in the db:
  - Connect to the MySQL container :
`mysql  -h{host} -u root -p{pass}`
  - Run the query and check the grade was stored.
``` sql
use edxapp;
SELECT * FROM grades_persistentsubsectiongrade WHERE modified > DATE_SUB(NOW(), INTERVAL 1 Hour) 
```
**Note**: In local could be openedx the main db.
![17-local](https://user-images.githubusercontent.com/51926076/147792361-42a13be7-1f09-4177-b859-9e3bdd726220.png)

### Stage results.



- submit as student in lms 
![lms-55](https://user-images.githubusercontent.com/51926076/147788068-45e84895-55d0-4b8e-912e-09ff6074acc1.png)
- grading  in cms
![cms-55](https://user-images.githubusercontent.com/51926076/147788067-b6cbbb38-a69b-4c2e-8f03-7fbe12b35f69.png)

- grading as staff in lms
![lms-66-note](https://user-images.githubusercontent.com/51926076/147788063-6882a499-30a7-48dc-8cd5-d5261c43b39f.png)
- grade course in db
![course-mysql](https://user-images.githubusercontent.com/51926076/147788061-af5aa255-a74f-44fa-9a50-5b4f12c196c8.png)
- grade sga subsection in MySQL 
![55-mysql](https://user-images.githubusercontent.com/51926076/147788211-81c45d01-64d0-4e2f-8169-58c5f96c99cb.png)

**extra**: 
- (cherry picked from commit 6985e1388b4af5f2dd06e3f372822a0abf249320)
- Jira: https://edunext.atlassian.net/browse/PS2021-1173?atlOrigin=eyJpIjoiOGNhMjE5MDdlYjBkNDAxMGE4ODg5ZThhNzUwNzg3M2QiLCJwIjoiaiJ9
## Checklist for Merge
- [x] Tested in local environment: stackbuilder  limonero local.
- [x] Tested in a remote environment: lilac stage
- [x] Rebased limonero.master
- [x] Squashed commits