### PR TITLE
chore: pin and update openedx-filters/events

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -60,7 +60,7 @@ markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, jinja2,
 newrelic==6.2.0.156       # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 oauthlib==3.0.1           # via -c requirements/edunext/../edx/base.txt, django-oauth-toolkit, requests-oauthlib, social-auth-core
 openedx-events==0.6.0     # via -r requirements/edunext/base.in, eox-hooks
-openedx-filters==0.3.0    # via -r requirements/edunext/base.in
+openedx-filters==0.3.1    # via -r requirements/edunext/base.in
 openedx-scorm-xblock==12.0.0  # via -r requirements/edunext/base.in
 git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock  # via -r requirements/edunext/github.in
 packaging==20.9           # via -c requirements/edunext/../edx/base.txt, drf-yasg

--- a/requirements/edunext/constraints.txt
+++ b/requirements/edunext/constraints.txt
@@ -7,3 +7,6 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+openedx-filters==0.3.1      # Pin working openedx-filters release until libraries are stable
+openedx-events==0.6.0       # Pin working openedx-events release until libraries are stable


### PR DESCRIPTION
**Description**
As part of JU-6 we should've pinned openedx-filters/openedx-events to the currently used versions until a more stable release.