### PR TITLE
Revert "feat: add site language config"

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -16,7 +16,6 @@ from django.utils.deprecation import MiddlewareMixin
 
 from openedx.core.djangoapps.dark_lang import DARK_LANGUAGE_KEY
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
-from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 
 # If django 1.7 or higher is used, the right-side can be updated with new-style codes.
@@ -92,16 +91,7 @@ class DarkLangMiddleware(MiddlewareMixin):
             return
 
         self._clean_accept_headers(request)
-        self._set_site_or_microsite_language(request)
         self._activate_preview_language(request)
-
-    def _set_site_or_microsite_language(self, request):
-        """
-        Apply language specified in site configuration.
-        """
-        language = get_value('LANGUAGE_CODE', None)
-        if language:
-            request.session[LANGUAGE_SESSION_KEY] = language
 
     def _fuzzy_match(self, lang_code):
         """Returns a fuzzy match for lang_code"""

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -13,7 +13,6 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 
 from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
-from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from common.djangoapps.student.tests.factories import UserFactory
 
@@ -256,16 +255,6 @@ class DarkLangMiddlewareTests(CacheIsolationTestCase):
         session = self.client.session
         session[LANGUAGE_SESSION_KEY] = session_language
         session.save()
-
-    @with_site_configuration(configuration={'LANGUAGE_CODE': 'rel'})
-    def test_site_configuration_language(self):
-        # `LANGUAGE_CODE` in site configuration should override session lang
-        self._set_client_session_language('notrel')
-        self.client.get('/home')
-        self.assert_session_lang_equals(
-            'rel',
-            self.client.session
-        )
 
     def test_preview_lang_with_released_language(self):
         # Preview lang should always override selection


### PR DESCRIPTION
## Description
This reverts commit 783327a97f8d7fbb6f8b0e9fb54ff49489e0d3b3. This commit was not supposed to be backported. It does not allow us to change the language using the LC-V2 changes.
More info: https://github.com/eduNEXT/edunext-platform/pull/612
