### PR TITLE
fix: handle opening verticals in new tabs with the "View In Studio"

### DIFF
--- a/lms/templates/preview_menu.html
+++ b/lms/templates/preview_menu.html
@@ -107,7 +107,7 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                 </a>
                 <script type="text/javascript">
                   $(function () {
-                      $('.wrapper-preview-menu a.view-in-studio').click(function (event) {
+                      $('.wrapper-preview-menu a.view-in-studio').focus(function (event) {
                           /*
                           When we start rendering this template, we
                           don't yet have a vertical in the context
@@ -115,9 +115,11 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                           if this is even on a unit-level page),
                           so we dynamically lookup the vertical element in
                           the DOM and use its data-* attributes to
-                          construct a Studio link directly to this unit.
-                          If no vertical is present, the link behaves as
-                          normal.
+                          construct a Studio link directly to this unit
+                          and replace the href attribute with it. If no
+                          vertical is present, the link directs to the
+                          course outline page in Studio.
+
                           */
                           var verticals = $('.xblock-student_view-vertical');
                           if (verticals.length > 0) {
@@ -127,12 +129,8 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
                                 'container',
                                 blockId,
                               ].join('/');
-                              window.location.href = url;
-                              return false;
+                              $(this).attr("href", url);
                           }
-                          // There's no vertical, so let the event
-                          // bubble up, ie, work like a normal link.
-                          return true;
                       });
                     });
                   </script>


### PR DESCRIPTION
## Description
Backport that fixes redirecting to Course Outline instead of verticals when using open in new page the button "View In Studio"

## Additional information
[PR](https://github.com/openedx/edx-platform/pull/27799/) in upstream

## How to test
1. Go to a course unit
2. Click "View in Studio" -> you should be redirected the course unit edit page
3. Now, use Open in new tab -> you should be redirected the course unit edit page