### PR TITLE
fix: fix field definition when it's uppercase

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -367,10 +367,8 @@ class RegistrationFormFactory:
         property allows us to add custom fields to the registration form using extended_profile_fields and
         REGISTRATION_EXTRA_FIELDS.
         """
-        extended_profile_fields = [field.lower() for field in getattr(settings, 'extended_profile_fields', [])]
-        extra_fields = [
-            field.lower() for field in configuration_helpers.get_value('REGISTRATION_EXTRA_FIELDS', {}).keys()
-        ]
+        extended_profile_fields = getattr(settings, 'extended_profile_fields', [])
+        extra_fields = list(configuration_helpers.get_value('REGISTRATION_EXTRA_FIELDS', {}))
 
         # Removing duplicates while mantaining order, important when running tests.
         return list(OrderedDict.fromkeys(self.EXTRA_FIELDS_BASE + extended_profile_fields + extra_fields))
@@ -661,7 +659,7 @@ class RegistrationFormFactory:
         """
         custom_fields = getattr(settings, "EDNX_CUSTOM_REGISTRATION_FIELDS", [])
         for field in custom_fields:
-            if field.get("name").lower() == field_name:
+            if field.get("name") == field_name:
                 return field
         return {}
 


### PR DESCRIPTION
## Description
This PR fixes a rendering error when there's a field definition with uppercase like in the settings shown in the testing section.

## How to test
### Settings
```
{
    "EDNX_CUSTOM_REGISTRATION_FIELDS": [
        {
            "label": "Mascota",
            "name": "Pet",
            "type": "text"
        }
    ],
    "EDNX_USE_SIGNAL": true,
    "JWT_EXTENDED_PROFILE": true,
    "PLATFORM_NAME": "lms",
    "REGISTRATION_EXTRA_FIELDS": {
        "Pet": "required"
    },
    "REGISTRATION_FIELD_ORDER": [
        "Pet",
        "email",
        "name",
        "username",
        "password",
        "country",
        "Affiliation",
        "company_name",
        "level_of_education",
        "gender",
        "year_of_birth",
        "goals",
        "honor_code",
        "data_consent"
    ],
    "THEME_OPTIONS": {
        "theme": {
            "name": "bragi-03a9f4",
            "parent": "bragi"
        }
    },
    "extended_profile_fields": [
        "Pet"
    ],
    "platform_name": "lms",
    "released_languages": "en,es-419,es-ES,pt-BR,pt-PT,ar,zh-CN,zh-TW,da,fr,de,el,he,it-IT,ja-jp,ko-KR,ru,vi,hi"
}
```
_Without changes_
![image](https://user-images.githubusercontent.com/64440265/150427041-81330339-0f02-44ad-b246-ba6234538dc2.png)
_After_
![image](https://user-images.githubusercontent.com/64440265/150560393-31c18180-72d2-4860-9278-76bf0778daf2.png)
