### PR TITLE
fix: avoid TypeError when comparing course.end with current date

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -502,7 +502,7 @@ class CertificateAvailableDate(DateSummary):
         Registers an alert close to the certificate delivery date.
         """
         is_enrolled = CourseEnrollment.get_enrollment(request.user, course.id)
-        if not is_enrolled or not self.is_enabled or course.end > self.current_time:
+        if not is_enrolled or not self.is_enabled or (course.end and course.end > self.current_time):
             return
         if self.date > self.current_time:
             CourseHomeMessages.register_info_message(


### PR DESCRIPTION
### Description
This PR fixes when comparing unset course.end with current date. 

### How to test
1. Import certificate demo course (optional)
[certificates_demo_course.tar.gz](https://github.com/eduNEXT/edunext-platform/files/7937195/certificates_demo_course.tar.gz)
2. Create a course mode that allows certificates generation
3. Configure certificate available date (Studio > Settings > Schedule & Details) 3 days from now
4. Activate the Waffle switch certificates.auto_certificate_generation
Then this message should pop up:
![image](https://user-images.githubusercontent.com/64440265/151063269-3533e90f-05cd-48b8-94d2-05a9bc0fb96c.png)
Without these changes, the application will crash with this error:
![image](https://user-images.githubusercontent.com/64440265/151063616-25b0ec1d-2fff-41fc-bd35-ac63efa3fc55.png)

[Duplicate in upstream](https://github.com/openedx/edx-platform/pull/29821)