### PR TITLE
feat: [AA-1082] fix 500 error on courses dashboard (#29290)

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -225,7 +225,7 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
             if library_children:
                 state_dict = get_student_module_as_dict(usage_info.user, usage_info.course_key, block_key)
                 current_children_blocks = {block.block_id for block in library_children}
-                current_selected_blocks = {item[1] for item in state_dict['selected']}
+                current_selected_blocks = {item[1] for item in state_dict.get('selected', [])}
 
                 # As the selections should have already been made by the ContentLibraryTransformer,
                 # the current children of the library_content block should be the same as the stored

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -2,7 +2,6 @@
 Tests for ContentLibraryTransformer.
 """
 
-
 from unittest import mock
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
@@ -18,6 +17,7 @@ class MockedModule:
     """
     Object with mocked selected modules for user.
     """
+
     def __init__(self, state):
         """
         Set state attribute on initialize.
@@ -154,7 +154,12 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                 self.course.location,
                 self.transformers,
             )
-            assert set(trans_block_structure.get_block_keys()) == self.get_block_key_set(self.blocks, 'course', 'chapter1', 'lesson1', 'vertical1', 'library_content1', selected_vertical, selected_child), f"Expected 'selected' equality failed in iteration {i}."  # pylint: disable=line-too-long
+            assert set(trans_block_structure.get_block_keys()) == self.get_block_key_set(self.blocks, 'course',
+                                                                                         'chapter1', 'lesson1',
+                                                                                         'vertical1',
+                                                                                         'library_content1',
+                                                                                         selected_vertical,
+                                                                                         selected_child), f"Expected 'selected' equality failed in iteration {i}."  # pylint: disable=line-too-long
 
 
 class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
@@ -313,6 +318,29 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
                 ['vertical', 'vertical_vertical3'],
             ]
         }
+
+        expected_children_without_hiding_or_gating = ['vertical_vertical3', ]
+
+        for _ in range(5):
+            trans_block_structure = get_course_blocks(
+                self.user,
+                self.course.location,
+                self.transformers,
+            )
+            children = []
+            for block_key in trans_block_structure.topological_traversal():
+                if block_key.block_type == 'library_content':
+                    children = trans_block_structure.get_children(block_key)
+                    break
+
+            assert expected_children_without_hiding_or_gating != [child.block_id for child in children]
+
+    @mock.patch('lms.djangoapps.course_blocks.transformers.library_content.get_student_module_as_dict')
+    def test_content_library_randomize_selected_blocks_missing(self, mocked):
+        """
+        Test that no selected blocks is handled gracefully
+        """
+        mocked.return_value = {}
 
         expected_children_without_hiding_or_gating = ['vertical_vertical3', ]
 


### PR DESCRIPTION
feat: [AA-1082] fix 500 error on courses dashboard

When there are no selected blocks, the dict comprehension to
compare is throwing an exception. Handle the error more gracefully.
The blocks will not be sorted, but they should not be filtered.

(cherry picked from commit 1d2319b42a8acd8b320fb6d8b92e7ac316ec0b0a)