### PR TITLE
refactor: use Django ORM instead of modulestore when getting course summaries

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -33,6 +33,8 @@ from common.djangoapps.student.roles import (
 )
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from xmodule.course_module import CourseSummary
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -61,17 +63,17 @@ class TestCourseListing(ModuleStoreTestCase):
         self.client = AjaxEnabledTestClient()
         self.client.login(username=self.user.username, password='test')
 
-    def _create_course_with_access_groups(self, course_location, user=None, store=ModuleStoreEnum.Type.split):
+    def _create_course_with_access_groups(self, course_location, user=None):
         """
         Create dummy course with 'CourseFactory' and role (instructor/staff) groups
         """
-        course = CourseFactory.create(
+        CourseFactory.create(
             org=course_location.org,
             number=course_location.course,
-            run=course_location.run,
-            default_store=store
+            run=course_location.run
         )
-        self._add_role_access_to_user(user, course.id)
+        course = CourseOverviewFactory.create(id=course_location, org=course_location.org)
+        self._add_role_access_to_user(user, course_location)
         return course
 
     def _add_role_access_to_user(self, user, course_id):
@@ -125,7 +127,7 @@ class TestCourseListing(ModuleStoreTestCase):
         Tests that CCX courses are filtered in course listing.
         """
         # Create a course and assign access roles to user.
-        course_location = self.store.make_course_key('Org1', 'Course1', 'Run1')
+        course_location = CourseLocator('Org1', 'Course1', 'Course1')
         course = self._create_course_with_access_groups(course_location, self.user)
 
         # Create a ccx course key and add assign access roles to user.
@@ -153,7 +155,10 @@ class TestCourseListing(ModuleStoreTestCase):
 
         # Verify that CCX courses are filtered out while iterating over all courses
         mocked_ccx_course = Mock(id=ccx_course_key)
-        with patch('xmodule.modulestore.mixed.MixedModuleStore.get_course_summaries', return_value=[mocked_ccx_course]):
+        with patch(
+            'openedx.core.djangoapps.content.course_overviews.models.CourseOverview.get_all_courses',
+            return_value=[mocked_ccx_course],
+        ):
             courses_iter, __ = _accessible_courses_iter_for_tests(self.request)
             self.assertEqual(len(list(courses_iter)), 0)
 
@@ -176,7 +181,7 @@ class TestCourseListing(ModuleStoreTestCase):
             # Create few courses
             for num in range(TOTAL_COURSES_COUNT):
                 course_location = self.store.make_course_key('Org', 'CreatedCourse' + str(num), 'Run')
-                self._create_course_with_access_groups(course_location, self.user, default_store)
+                self._create_course_with_access_groups(course_location, self.user)
 
         # Fetch accessible courses list & verify their count
         courses_list_by_staff, __ = get_courses_accessible_to_user(self.request)
@@ -196,7 +201,7 @@ class TestCourseListing(ModuleStoreTestCase):
         """
         with self.store.default_store(store):
             course_key = self.store.make_course_key('Org', 'Course', 'Run')
-            self._create_course_with_access_groups(course_key, self.user, store)
+            course = self._create_course_with_access_groups(course_key, self.user)
 
         # get courses through iterating all courses
         courses_iter, __ = _accessible_courses_iter_for_tests(self.request)
@@ -221,6 +226,7 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertEqual(course_keys_in_course_list, course_keys_in_courses_list_by_groups)
         # now delete this course and re-add user to instructor group of this course
         delete_course(course_key, self.user.id)
+        course.delete()
 
         CourseInstructorRole(course_key).add_users(self.user)
 
@@ -240,8 +246,8 @@ class TestCourseListing(ModuleStoreTestCase):
         )
 
     @ddt.data(
-        (ModuleStoreEnum.Type.split, 3, 3),
-        (ModuleStoreEnum.Type.mongo, 2, 2)
+        (ModuleStoreEnum.Type.split, 1, 2),
+        (ModuleStoreEnum.Type.mongo, 1, 2),
     )
     @ddt.unpack
     def test_course_listing_performance(self, store, courses_list_from_group_calls, courses_list_calls):
@@ -261,9 +267,9 @@ class TestCourseListing(ModuleStoreTestCase):
                 run = f'Run{number}'
                 course_location = self.store.make_course_key(org, course, run)
                 if number in user_course_ids:
-                    self._create_course_with_access_groups(course_location, self.user, store=store)
+                    self._create_course_with_access_groups(course_location, self.user)
                 else:
-                    self._create_course_with_access_groups(course_location, store=store)
+                    self._create_course_with_access_groups(course_location)
 
         # get courses by iterating through all courses
         courses_iter, __ = _accessible_courses_iter_for_tests(self.request)
@@ -281,30 +287,23 @@ class TestCourseListing(ModuleStoreTestCase):
         courses_list, __ = _accessible_courses_list_from_groups(self.request)
         self.assertEqual(len(courses_list), USER_COURSES_COUNT)
 
-        # Now count the db queries
-        with check_mongo_calls(courses_list_from_group_calls):
+        with self.assertNumQueries(courses_list_from_group_calls, table_blacklist=WAFFLE_TABLES):
             _accessible_courses_list_from_groups(self.request)
 
-        with check_mongo_calls(courses_list_calls):
-            list(_accessible_courses_iter_for_tests(self.request))
-        # Calls:
-        #    1) query old mongo
-        #    2) get_more on old mongo
-        #    3) query split (but no courses so no fetching of data)
+        with self.assertNumQueries(courses_list_calls, table_blacklist=WAFFLE_TABLES):
+            _accessible_courses_iter_for_tests(self.request)
 
-    @ddt.data(ModuleStoreEnum.Type.split, ModuleStoreEnum.Type.mongo)
-    def test_course_listing_errored_deleted_courses(self, store):
+    def test_course_listing_errored_deleted_courses(self):
         """
         Create good courses, courses that won't load, and deleted courses which still have
         roles. Test course listing.
         """
-        with self.store.default_store(store):
-            course_location = self.store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
-            self._create_course_with_access_groups(course_location, self.user, store)
+        course_location = CourseLocator('testOrg', 'testCourse', 'RunBabyRun')
+        self._create_course_with_access_groups(course_location, self.user)
 
-            course_location = self.store.make_course_key('testOrg', 'doomedCourse', 'RunBabyRun')
-            self._create_course_with_access_groups(course_location, self.user, store)
-            self.store.delete_course(course_location, self.user.id)
+        course_location = CourseLocator('doomedCourse', 'testCourse', 'RunBabyRun')
+        course = self._create_course_with_access_groups(course_location, self.user)
+        course.delete()
 
         courses_list, __ = _accessible_courses_list_from_groups(self.request)
         self.assertEqual(len(courses_list), 1, courses_list)
@@ -339,7 +338,7 @@ class TestCourseListing(ModuleStoreTestCase):
         # Verify fetched accessible courses list is a list of CourseSummery instances and test expacted
         # course count is returned
         self.assertEqual(len(list(courses_list)), 2)
-        self.assertTrue(all(isinstance(course, CourseSummary) for course in courses_list))
+        self.assertTrue(all(isinstance(course, CourseOverview) for course in courses_list))
 
     @ddt.data(OrgStaffRole(), OrgInstructorRole())
     def test_course_listing_org_permissions_exception(self, role):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -465,7 +465,7 @@ def _accessible_courses_iter_for_tests(request):
 
         return has_studio_read_access(request.user, course.id)
 
-    courses = filter(course_filter, modulestore().get_course_summaries())
+    courses = filter(course_filter, CourseOverview.get_all_courses())
 
     in_process_course_actions = get_in_process_course_actions(request)
     return courses, in_process_course_actions


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR improves studio course listing performance for users with course access roles like staff or instructor, by changing from MongoDB queries to Mysql queries.

We measured the improvements as follows:

After 100 requests:

| Number of courses | Avg time elapsed before (s)  | Avg time elapsed after (s) |
|---------------------------|---------------------------------------|------------------------------------|
|         50                   |                2.34                        |         2.28                           |
|         107                 |                3.16                        |         2.57                           |
|         548                 |                7.91                        |         3.16                           |
|         1069               |                Error 500                |         4.62                           |
|         3380               |                Error 500                |         8.21                           |


If you go to /home using users with access roles staff/instructor in an org with more than ~500 courses, the page will collapse and raise a Network Timeout.

**Versions**
Mongo 4.0
MySQL 5.7
Lilac release

## Testing instructions

Go to Studio Home with a user with access roles (instructor/staff) over an organization, then the list of courses must match the CourseOverviews.

## Other information

According to [this](https://discuss.openedx.org/t/adr-for-removing-mongodb-from-edx-platform/6001), this change won't be necessary after deprecating MongoDB from edxapp.

I cherry-picked from [upstream PR](https://github.com/openedx/edx-platform/pull/29944). I'm not sure whether they're going to accept the PR, but the main goal is to discuss our performance issues and this solution.