### PR TITLE
fix: Change link to edx-guide on calculator help

### DIFF
--- a/lms/static/js/fixtures/calculator.html
+++ b/lms/static/js/fixtures/calculator.html
@@ -13,8 +13,8 @@
                         <li class="hint-item" id="hint-moreinfo" tabindex="-1">
                             <p>
                                 <span class="bold">For detailed information, see
-                                <a id="hint-link-first" href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">Entering Mathematical and Scientific Expressions</a> in the
-                                <a id="hint-link-second" href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">EdX Learner's Guide</a>.
+                                <a id="hint-link-first" target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-lilac.master/completing_assignments/SFD_mathformatting.html">Entering Mathematical and Scientific Expressions</a> in the
+                                <a id="hint-link-second" target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-lilac.master/index.html">EdX Learner's Guide</a>.
                                 </span>
                             </p>
                         </li>

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -25,9 +25,9 @@ from openedx.core.djangolib.markup import HTML, Text
                             <p>
                                 <span class="bold">
                                     ${Text(_("For detailed information, see {math_link_start}Entering Mathematical and Scientific Expressions{math_link_end} in the {guide_link_start}edX Guide for Students{guide_link_end}.")).format(
-                                        math_link_start=HTML('<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">'),
+                                        math_link_start=HTML('<a target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-lilac.master/completing_assignments/SFD_mathformatting.html">'),
                                         math_link_end=HTML('</a>'),
-                                        guide_link_start=HTML('<a href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">'),
+                                        guide_link_start=HTML('<a target="_blank" href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/open-release-lilac.master/index.html">'),
                                         guide_link_end=HTML('</a>'),
                                     )}
                                 </span>


### PR DESCRIPTION
Based on the ticket [#18167] the links for the documentation of the calculator on the edx-guide-for-students were corrected to the used on open-release.lilac 