### PR TITLE
ci: add distro nightly tag to github workflows

### DIFF
--- a/.github/workflows/distro-nightly-tag.yml
+++ b/.github/workflows/distro-nightly-tag.yml
@@ -1,0 +1,27 @@
+name: Distro nigthly tag
+
+on:
+  schedule:
+    - cron: '00 04 * * *'
+
+jobs:
+  nightly-tag:
+    runs-on: ubuntu-20.04
+    name: Create nightly tag
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+      - name: get the last commit of day
+        id: last-commit-of-day
+        run: |
+          hash=$(git --no-pager log -1 --format="%h" --since=23.hours)
+          echo "::set-output name=COMMITHASH::${hash}"
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=NOW::$(date +'%Y%m%d')"
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: vL.N${{ steps.date.outputs.NOW }}${{steps.last-commit-of-day.outputs.COMMITHASH}}

--- a/.github/workflows/distro-nightly-tag.yml
+++ b/.github/workflows/distro-nightly-tag.yml
@@ -24,4 +24,4 @@ jobs:
         uses: tvdias/github-tagger@v0.0.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: vL.N${{ steps.date.outputs.NOW }}${{steps.last-commit-of-day.outputs.COMMITHASH}}
+          tag: nightly/vL.N${{ steps.date.outputs.NOW }}${{steps.last-commit-of-day.outputs.COMMITHASH}}


### PR DESCRIPTION
## Description
This commit is a proposal to create each day one tag with the changes of the day.

This may be the first part of the CI that will build a new image for each nightly tag.

## How it works
This has a cronjob that will run daily at 04:00 (UTC) or 23:00 (Colombia TIme), then, this will check if there are new commits in a range of 23 hours if there aren't this won't create a tag.

### Tag format
```
nightly/vL.N20200414d2d0a67
         | |   |    |___ Last commit's hash (d2d0a67)
         | |   |___ Current date (2020-04-14)
         | |___ N: Nightly tag
         |___ eduNEXT distro release
```