### PR TITLE
N2 - fix: Use currency defined in the settings

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
@@ -2,6 +2,12 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.urls import reverse
+from django.conf import settings
+
+try:
+    currency = settings.PAID_COURSE_REGISTRATION_CURRENCY[0]
+except:
+    currency = 'usd'
 %>
 <section id="set-course-mode-price-modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-course-price">
     <h2 id="header-course-price" class="hd hd-2">${_("Set Course Mode Price")}</h2>
@@ -37,7 +43,7 @@ from django.urls import reverse
             <li class="field required text" id="set-course-mode-modal-field-currency">
               <label for="course_mode_currency" class="required text">${_("Currency")}</label>
               <select class="field required" id="course_mode_currency" name="currency">
-                <option value="usd">USD</option>
+	         <option value="${currency}">${currency.upper()}</option>
               </select>
             </li>
           </ol>


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR allows to use the PAID_COURSE_REGISTRATION_CURRENCY currency.

## Other info

[Juniper commit](https://github.com/fccn/edx-platform/commit/1a6417792e553262a2e9945231cc19fd1d12207e)
[Jira issue](https://edunext.atlassian.net/browse/DS-91?atlOrigin=eyJpIjoiMDFiMTNkYjgwMTBjNGZmMjlkYTI5ZTMyM2FkYWI5NDQiLCJwIjoiaiJ9)
[Migration excel](https://docs.google.com/spreadsheets/d/1QCF3H_rYWm4wRCcchCV0UqhQjjKYUQOKneywkU2IM88/edit?usp=sharing)