### PR TITLE
N4 - feat: adding educast token on lms and studio base templates

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -17,6 +17,7 @@ from openedx.core.djangolib.js_utils import (
 )
 from openedx.core.djangolib.markup import HTML
 from openedx.core.release import RELEASE_LINE
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%page expression_filter="h"/>
@@ -63,6 +64,11 @@ from openedx.core.release import RELEASE_LINE
     <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
+    <% educast_site_id = configuration_helpers.get_value('EDUCAST_SITE_ID', '')%>
+    % if user.is_authenticated and educast_site_id:
+    <meta name="integration" content="${educast_site_id}">
+    % endif
+
     <% favicon_url = branding_api.get_favicon_url() %>
     <link rel="icon" type="image/x-icon" href="${favicon_url}"/>
     <%static:css group='style-vendor'/>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -146,6 +146,11 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <meta name="google-site-verification" content="${google_site_verification_id}" />
   % endif
 
+  <% educast_site_id = configuration_helpers.get_value('EDUCAST_SITE_ID', '')%>
+  % if educast_site_id:
+    <meta name="integration" content="${educast_site_id}">
+  % endif
+
   <meta name="openedx-release-line" content="${RELEASE_LINE}" />
 
 <% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds educast token on lms and studio.

## Other info

[Juniper commit](https://github.com/fccn/edx-platform/commit/3b488e6d733e50c6c9191404c15021f847b5c6d2)
[Jira issue](https://edunext.atlassian.net/browse/DS-96?atlOrigin=eyJpIjoiYTBjZDY3YTEyNmE4NDM1ZmE0OTFmYTc4MmIwODk3ZjkiLCJwIjoiaiJ9)
[Migration excel](https://docs.google.com/spreadsheets/d/1QCF3H_rYWm4wRCcchCV0UqhQjjKYUQOKneywkU2IM88/edit?usp=sharing)

At the moment I am relying on the github tests that have 7 patches, lms and cms