### PR TITLE
feat: add first batch of Open edX Filters

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -68,7 +68,7 @@ from openedx_events.learning.signals import (
     COURSE_ENROLLMENT_CREATED,
     COURSE_UNENROLLMENT_COMPLETED,
 )
-from openedx_filters.learning.enrollment import PreEnrollmentFilter
+from openedx_filters.learning.filters import CourseEnrollmentStarted
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
 from common.djangoapps.course_modes.models import CourseMode, get_cosmetic_verified_display_price
 from common.djangoapps.student.emails import send_proctoring_requirements_email
@@ -1620,10 +1620,10 @@ class CourseEnrollment(models.Model):
         Also emits relevant events for analytics purposes.
         """
         try:
-            user, course_key, mode = PreEnrollmentFilter.run(
+            user, course_key, mode = CourseEnrollmentStarted.run_filter(
                 user=user, course_key=course_key, mode=mode,
             )
-        except PreEnrollmentFilter.PreventEnrollment as exc:
+        except CourseEnrollmentStarted.PreventEnrollment as exc:
             raise EnrollmentNotAllowed(str(exc)) from exc
 
         if mode is None:

--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -2,16 +2,14 @@
 Test that various filters are fired for models in the student app.
 """
 from django.test import override_settings
-from openedx_filters.learning.enrollment import PreEnrollmentFilter
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+from openedx_filters.learning.filters import CourseEnrollmentStarted
 from openedx_filters import PipelineStep
 
 from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
-
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class TestEnrollmentPipelineStep(PipelineStep):
@@ -19,10 +17,10 @@ class TestEnrollmentPipelineStep(PipelineStep):
     Utility function used when getting steps for pipeline.
     """
 
-    def run(self, user, course_key, mode):  # pylint: disable=unused-argument, arguments-differ
+    def run_filter(self, user, course_key, mode):  # pylint: disable=arguments-differ
         """Pipeline steps that changes mode to honor."""
         if mode == "no-id-professional":
-            raise PreEnrollmentFilter.PreventEnrollment()
+            raise CourseEnrollmentStarted.PreventEnrollment()
         return {"mode": "honor"}
 
 
@@ -33,7 +31,7 @@ class EnrollmentFiltersTest(ModuleStoreTestCase):
 
     This class guarantees that the following filters are triggered during the user's enrollment:
 
-    - PreEnrollmentFilter
+    - CourseEnrollmentStarted
     """
 
     def setUp(self):  # pylint: disable=arguments-differ
@@ -62,7 +60,7 @@ class EnrollmentFiltersTest(ModuleStoreTestCase):
         enrollment process.
 
         Expected result:
-            - PreEnrollmentFilter is triggered and executes TestEnrollmentPipelineStep.
+            - CourseEnrollmentStarted is triggered and executes TestEnrollmentPipelineStep.
             - The arguments that the receiver gets are the arguments used by the filter
             with the enrollment mode changed.
         """
@@ -85,8 +83,22 @@ class EnrollmentFiltersTest(ModuleStoreTestCase):
         Test prevent the user's enrollment through a pipeline step.
 
         Expected result:
-            - PreEnrollmentFilter is triggered and executes TestEnrollmentPipelineStep.
+            - CourseEnrollmentStarted is triggered and executes TestEnrollmentPipelineStep.
             - The user can't enroll.
         """
         with self.assertRaises(EnrollmentNotAllowed):
             CourseEnrollment.enroll(self.user, self.course.id, mode='no-id-professional')
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_enrollment_without_filter_configuration(self):
+        """
+        Test usual enrollment process, without filter's intervention.
+
+        Expected result:
+            - CourseEnrollmentStarted does not have any effect on the enrollment process.
+            - The enrollment process ends successfully.
+        """
+        enrollment = CourseEnrollment.enroll(self.user, self.course.id, mode='audit')
+
+        self.assertEqual('audit', enrollment.mode)
+        self.assertTrue(CourseEnrollment.is_enrolled(self.user, self.course.id))

--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -9,7 +9,11 @@ from openedx_filters import PipelineStep
 
 from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
+
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class TestEnrollmentPipelineStep(PipelineStep):

--- a/common/djangoapps/student/tests/test_filters.py
+++ b/common/djangoapps/student/tests/test_filters.py
@@ -2,18 +2,14 @@
 Test that various filters are fired for models in the student app.
 """
 from django.test import override_settings
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import CourseEnrollmentStarted
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from openedx_filters.learning.filters import CourseEnrollmentStarted
-from openedx_filters import PipelineStep
 
 from common.djangoapps.student.models import CourseEnrollment, EnrollmentNotAllowed
 from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
-
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class TestEnrollmentPipelineStep(PipelineStep):
@@ -21,7 +17,7 @@ class TestEnrollmentPipelineStep(PipelineStep):
     Utility function used when getting steps for pipeline.
     """
 
-    def run_filter(self, user, course_key, mode):  # pylint: disable=arguments-differ
+    def run_filter(self, user, course_key, mode):  # pylint: disable=arguments-differ, unused-argument
         """Pipeline steps that changes mode to honor."""
         if mode == "no-id-professional":
             raise CourseEnrollmentStarted.PreventEnrollment()

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -30,6 +30,8 @@ from rest_framework.views import APIView
 
 from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import SESSION_LOGIN_COMPLETED
+from openedx_filters.learning.filters import StudentLoginRequested
+
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -514,6 +516,13 @@ def login_user(request):
         _check_excessive_login_attempts(user)
 
         possibly_authenticated_user = user
+
+        try:
+            possibly_authenticated_user = StudentLoginRequested.run_filter(user=possibly_authenticated_user)
+        except StudentLoginRequested.PreventLogin as exc:
+            raise AuthFailedError(
+                str(exc), redirect_url=exc.redirect_to, error_code=exc.error_code, context=exc.context,
+            ) from exc
 
         if not is_user_third_party_authenticated:
             possibly_authenticated_user = _authenticate_first_party(request, user, third_party_auth_requested)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -521,7 +521,10 @@ def login_user(request):
             possibly_authenticated_user = StudentLoginRequested.run_filter(user=possibly_authenticated_user)
         except StudentLoginRequested.PreventLogin as exc:
             raise AuthFailedError(
-                str(exc), redirect_url=exc.redirect_to, error_code=exc.error_code, context=exc.context,
+                str(exc),
+                redirect_url=exc.redirect_to,  # pylint: disable=no-member
+                error_code=exc.error_code,  # pylint: disable=no-member
+                context=exc.context,  # pylint: disable=no-member
             ) from exc
 
         if not is_user_third_party_authenticated:

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -25,6 +25,7 @@ from edx_django_utils.monitoring import set_custom_attribute
 from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx_events.learning.data import UserData, UserPersonalData
 from openedx_events.learning.signals import STUDENT_REGISTRATION_COMPLETED
+from openedx_filters.learning.filters import StudentRegistrationRequested
 from pytz import UTC
 from ratelimit.decorators import ratelimit
 from requests import HTTPError
@@ -535,6 +536,14 @@ class RegistrationView(APIView):
 
         data = request.POST.copy()
         self._handle_terms_of_service(data)
+
+        try:
+            data = StudentRegistrationRequested.run_filter(form_data=data)
+        except StudentRegistrationRequested.PreventRegistration as exc:
+            errors = {
+                "error_message": [{"user_message": str(exc)}],
+            }
+            return self._create_response(request, errors, status_code=exc.status_code)
 
         response = self._handle_duplicate_email_username(request, data)
         if response:

--- a/openedx/core/djangoapps/user_authn/views/tests/test_filters.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_filters.py
@@ -1,0 +1,274 @@
+"""
+Test that various filters are fired for the vies in the user_authn app.
+"""
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from openedx_filters import PipelineStep
+from openedx_filters.learning.filters import StudentLoginRequested, StudentRegistrationRequested
+from rest_framework import status
+
+from common.djangoapps.student.tests.factories import UserFactory, UserProfileFactory
+from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+
+User = get_user_model()
+
+
+class TestRegisterPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, form_data):  # pylint: disable=arguments-differ
+        """Pipeline steps that changes the user's username."""
+        username = f"{form_data.get('username')}-OpenEdx"
+        form_data["username"] = username
+        return {
+            "form_data": form_data,
+        }
+
+
+class TestAnotherRegisterPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, form_data):  # pylint: disable=arguments-differ
+        """Pipeline steps that changes the user's username."""
+        username = f"{form_data.get('username')}-Test"
+        form_data["username"] = username
+        return {
+            "form_data": form_data,
+        }
+
+
+class TestStopRegisterPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, form_data):  # pylint: disable=arguments-differ
+        """Pipeline steps that stops the user's registration process."""
+        raise StudentRegistrationRequested.PreventRegistration("You can't register on this site.", status_code=403)
+
+
+class TestLoginPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, user):  # pylint: disable=arguments-differ
+        """Pipeline steps that adds a field to the user's profile."""
+        user.profile.set_meta({"logged_in": True})
+        user.profile.save()
+        return {
+            "user": user
+        }
+
+
+class TestAnotherLoginPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, user):  # pylint: disable=arguments-differ
+        """Pipeline steps that adds a field to the user's profile."""
+        new_meta = user.profile.get_meta()
+        new_meta.update({"another_logged_in": True})
+        user.profile.set_meta(new_meta)
+        user.profile.save()
+        return {
+            "user": user
+        }
+
+
+class TestStopLoginPipelineStep(PipelineStep):
+    """
+    Utility function used when getting steps for pipeline.
+    """
+
+    def run_filter(self, user):  # pylint: disable=arguments-differ
+        """Pipeline steps that stops the user's login."""
+        raise StudentLoginRequested.PreventLogin("You can't login on this site.")
+
+
+@skip_unless_lms
+class RegistrationFiltersTest(UserAPITestCase):
+    """
+    Tests for the Open edX Filters associated with the user registration process.
+
+    This class guarantees that the following filters are triggered during the user's registration:
+
+    - StudentRegistrationRequested
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.url = reverse("user_api_registration")
+        self.user_info = {
+            "email": "user@example.com",
+            "name": "Test User",
+            "username": "test",
+            "password": "password",
+            "honor_code": "true",
+        }
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.registration.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestRegisterPipelineStep",
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestAnotherRegisterPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_register_filter_executed(self):
+        """
+        Test whether the student register filter is triggered before the user's
+        registration process.
+
+        Expected result:
+            - StudentRegistrationRequested is triggered and executes TestRegisterPipelineStep.
+            - The user's username is updated.
+        """
+        self.client.post(self.url, self.user_info)
+
+        user = User.objects.filter(username=f"{self.user_info.get('username')}-OpenEdx-Test")
+        self.assertTrue(user)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.registration.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestRegisterPipelineStep",
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestStopRegisterPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_register_filter_prevent_registration(self):
+        """
+        Test prevent the user's registration through a pipeline step.
+
+        Expected result:
+            - StudentRegistrationRequested is triggered and executes TestStopRegisterPipelineStep.
+            - The user's registration stops.
+        """
+        response = self.client.post(self.url, self.user_info)
+
+        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_register_without_filter_configuration(self):
+        """
+        Test usual registration process, without filter's intervention.
+
+        Expected result:
+            - StudentRegistrationRequested does not have any effect on the registration process.
+            - The registration process ends successfully.
+        """
+        self.client.post(self.url, self.user_info)
+
+        user = User.objects.filter(username=f"{self.user_info.get('username')}")
+        self.assertTrue(user)
+
+
+@skip_unless_lms
+class LoginFiltersTest(UserAPITestCase):
+    """
+    Tests for the Open edX Filters associated with the user login process.
+
+    This class guarantees that the following filters are triggered during the user's login:
+
+    - StudentLoginRequested
+    """
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.user = UserFactory.create(
+            username="test",
+            email="test@example.com",
+            password="password",
+        )
+        self.user_profile = UserProfileFactory.create(user=self.user, name="Test Example")
+        self.url = reverse('login_api')
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.login.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestLoginPipelineStep",
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestAnotherLoginPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_login_filter_executed(self):
+        """
+        Test whether the student login filter is triggered before the user's
+        login process.
+
+        Expected result:
+            - StudentLoginRequested is triggered and executes TestLoginPipelineStep.
+            - The user's profile is updated.
+        """
+        data = {
+            "email": "test@example.com",
+            "password": "password",
+        }
+
+        self.client.post(self.url, data)
+
+        user = User.objects.get(username=self.user.username)
+        self.assertDictEqual({"logged_in": True, "another_logged_in": True}, user.profile.get_meta())
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.student.login.requested.v1": {
+                "pipeline": [
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestLoginPipelineStep",
+                    "openedx.core.djangoapps.user_authn.views.tests.test_filters.TestStopLoginPipelineStep",
+                ],
+                "fail_silently": False,
+            },
+        },
+    )
+    def test_login_filter_prevent_login(self):
+        """
+        Test prevent the user's login through a pipeline step.
+
+        Expected result:
+            - StudentLoginRequested is triggered and executes TestStopLoginPipelineStep.
+            - Test prevent the user's login through a pipeline step.
+        """
+        data = {
+            "email": "test@example.com",
+            "password": "password",
+        }
+
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+    @override_settings(OPEN_EDX_FILTERS_CONFIG={})
+    def test_login_without_filter_configuration(self):
+        """
+        Test usual login process, without filter's intervention.
+
+        Expected result:
+            - StudentLoginRequested does not have any effect on the login process.
+            - The login process ends successfully.
+        """
+        data = {
+            "email": "test@example.com",
+            "password": "password",
+        }
+
+        response = self.client.post(self.url, data)
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -60,7 +60,7 @@ markupsafe==1.1.1         # via -c requirements/edunext/../edx/base.txt, jinja2,
 newrelic==6.2.0.156       # via -c requirements/edunext/../edx/base.txt, edx-django-utils
 oauthlib==3.0.1           # via -c requirements/edunext/../edx/base.txt, django-oauth-toolkit, requests-oauthlib, social-auth-core
 openedx-events==0.6.0     # via -r requirements/edunext/base.in, eox-hooks
-openedx-filters==0.3.1    # via -r requirements/edunext/base.in
+openedx-filters==0.4.3    # via -r requirements/edunext/base.in
 openedx-scorm-xblock==12.0.0  # via -r requirements/edunext/base.in
 git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock  # via -r requirements/edunext/github.in
 packaging==20.9           # via -c requirements/edunext/../edx/base.txt, drf-yasg

--- a/requirements/edunext/constraints.txt
+++ b/requirements/edunext/constraints.txt
@@ -8,5 +8,5 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-openedx-filters==0.3.1      # Pin working openedx-filters release until libraries are stable
+openedx-filters==0.4.3      # Pin working openedx-filters release until libraries are stable
 openedx-events==0.6.0       # Pin working openedx-events release until libraries are stable


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR backports the 1st filters batch 

* Add enrollment filter (just updates the filter definition so it works with the newer openedx-filters)
* Add register filter
* Add login filter

(cherry picked from commit f29a4eef68cc8d8ebbce21025b37db6566997225)

## Supporting information

Upstream PR https://github.com/openedx/edx-platform/pull/29449

## Testing instructions

Review upstream PR

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

After merging this, one of our private plugins that use openedx-events must be updated.
