### PR TITLE
fix: change locale_paths to be a list

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1827,7 +1827,7 @@ def _make_locale_paths_prepend(settings):   # pylint: disable=missing-function-d
         # Add locale paths to settings for comprehensive theming.
         for locale_path in settings.COMPREHENSIVE_THEME_LOCALE_PATHS:
             locale_paths = (path(locale_path), ) + locale_paths
-    return locale_paths
+    return list(locale_paths)
 
 LOCALE_PATHS = _make_locale_paths_prepend
 derived('LOCALE_PATHS')


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR corrects the type of `locale_paths`, locale_paths needs to be a list.

## Supporting information

Before #639 [locale_paths was a list](https://github.com/eduNEXT/edunext-platform/blob/edunext/limonero.nau/lms/envs/common.py#L1816).