### PR TITLE
feat: adding scorm-proxy requirement

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -113,6 +113,7 @@ git+https://github.com/eduNEXT/xblock-image-explorer.git@update-lilac-import#egg
 git+https://github.com/open-craft/problem-builder.git@v5.0.0#egg=xblock-problem-builder==5.0.0  # via -r requirements/edunext/github.in
 xblock-utils==2.1.2       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-problem-builder
 xblock==1.4.0             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, openedx-scorm-xblock, oppia-xblock, pdf-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
+git+https://github.com/eduNEXT/eox-scorm-proxy.git@poc#egg=eox-scorm-xblock==0.1.0  # via -r requirements/edunext/github.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edunext/github.in
+++ b/requirements/edunext/github.in
@@ -85,3 +85,6 @@ git+https://github.com/eduNEXT/webhook-xblock@a734c6de47cb61cba20bec4a4f3362ce62
 
 # xblock-pdf
 git+https://github.com/appsembler/pdfXBlock.git@v0.3.1#egg=pdf-xblock==0.3.1
+
+# Scorm proxy
+git+https://github.com/eduNEXT/eox-scorm-proxy.git@poc#egg=eox-scorm-xblock==0.1.0


### PR DESCRIPTION
Adding scorm-proxy plugin to allow proxy scorm components using openedx-scorm-xblock