### PR TITLE
feat: adding annoto xblock requirement

### DIFF
--- a/requirements/edunext/base.txt
+++ b/requirements/edunext/base.txt
@@ -114,6 +114,7 @@ git+https://github.com/open-craft/problem-builder.git@v5.0.0#egg=xblock-problem-
 xblock-utils==2.1.2       # via -c requirements/edunext/../edx/base.txt, activetable-xblock, flow-control-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-problem-builder
 xblock==1.4.0             # via -c requirements/edunext/../edx/base.txt, activetable-xblock, edx-when, flow-control-xblock, openedx-scorm-xblock, oppia-xblock, pdf-xblock, schoolyourself-xblock, scormxblock-xblock, surveymonkey-xblock, ubcpi-xblock, vectordraw-xblock, webhook-xblock, xblock-free-text-response, xblock-image-explorer, xblock-problem-builder, xblock-utils
 git+https://github.com/eduNEXT/eox-scorm-proxy.git@poc#egg=eox-scorm-xblock==0.1.0  # via -r requirements/edunext/github.in
+git+https://github.com/Annoto/xblock-in-video-collaboration.git#egg=xblock_annoto # via -r requirements/edunext/github.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
The annoto xblock was fixed to run smoothly, it was installed on stage and can be seen running at this [link](https://testing-site3-edunext-io.le.edunextstage.net/courses/course-v1:testing-site+TS+00/courseware/983317c9de26485daa6480f69aa266a8/973081d2ab274a21ae5b708a4ab0dff3/?activate_block_id=block-v1%3Atesting-site%2BTS%2B00%2Btype%40sequential%2Bblock%40973081d2ab274a21ae5b708a4ab0dff3)

In order to test it you can follow the instructions in this [documentation](https://docs.annoto.net/setup-guides/openedx/widget-integration-xblock) 