### PR TITLE
fix: display right-to-left for rtl-languages in mobile

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -366,7 +366,7 @@
         width: 100%;
         padding: $baseline*0.6 $baseline;
         border-bottom: 1px solid theme-color('light');
-        text-align: left;
+        @include text-align(left);
         cursor: pointer;
 
         &:hover,


### PR DESCRIPTION
## Description

Backport of this https://github.com/openedx/edx-platform/pull/28861
