### PR TITLE
Jlc/migration language code

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -108,7 +108,7 @@ class DarkLangMiddleware(MiddlewareMixin):
         Apply language specified in site configuration.
         """
         language = get_value('LANGUAGE_CODE', None)
-        if language:
+        if language and not request.COOKIES.get(settings.LANGUAGE_COOKIE, None):
             request.session[LANGUAGE_SESSION_KEY] = language
             set_language_cookie(request, response, language)
 

--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -108,7 +108,7 @@ class DarkLangMiddleware(MiddlewareMixin):
         Apply language specified in site configuration.
         """
         language = get_value('LANGUAGE_CODE', None)
-        if language and not request.COOKIES.get(settings.LANGUAGE_COOKIE, None):
+        if language and not request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME, None):
             request.session[LANGUAGE_SESSION_KEY] = language
             set_language_cookie(request, response, language)
 


### PR DESCRIPTION
# Description
Migration for `LANGUAGE_CODE` fix

Previous PR: https://github.com/eduNEXT/edx-platform/pull/268

