### PR TITLE
Fix to prevent 500 error when course mode currency is not the same as…

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -761,7 +761,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        return min(
+            (mode.min_price for mode in modes if mode.currency.lower() == currency.lower()),
+            default=0
+        )
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):


### PR DESCRIPTION
# Description 
Cherrypick for migration in nelp.
 - (cherry picked from commit https://github.com/eduNEXT/edunext-platform/commit/9d678442ab5ee6afc1240c6741e5cbb745fea246)
- (cherry picked from commit b84b84daffde9d26b7264c72b2f6d4631ab3a286)

This is not based on exact ansible configuration, it is based on config loaded in Django settings.

# Explanation 

The problem is with a course when it is verified and you give it a currency different from the currency setting

For example looking at my settings the currency var is loaded with USD:
![2022-10-03_19-04](https://user-images.githubusercontent.com/51926076/193707766-e8e41761-412b-46d9-bb77-157a040de5da.png)
![2022-10-03_19-02](https://user-images.githubusercontent.com/51926076/193707767-7521ed56-8d0f-4025-aa3c-fc4ca552f319.png)

So when I configure a course with a currency different from USD from example cop.
![2022-10-03_19-20](https://user-images.githubusercontent.com/51926076/193708534-f01cc0bd-e974-4cf5-9928-c481532e6b01.png)



And then  I load this course with the about page there is a 500 error.
![2022-10-03_18-58_1](https://user-images.githubusercontent.com/51926076/193707806-12c2ab13-5690-4e07-8930-bdcaed8a45d6.png)

## After 
No way, with this fix, the price is avoided and at least quit the 500 error. To get the exact price I have to match the currency with the currency from `COURSE_MODES_DEFAULTS`

![2022-10-03_19-06](https://user-images.githubusercontent.com/51926076/193707927-5e8405c4-1a7d-43f7-a0ae-2d50add915a5.png)
