### PR TITLE
feat: control linked account by settings

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -13,6 +13,7 @@
         return function(
             fieldsData,
             disableOrderHistoryTab,
+            showLinkedAccountsTab,
             ordersHistoryData,
             authData,
             passwordResetSupportUrl,
@@ -426,6 +427,7 @@
                 },
                 userPreferencesModel: userPreferencesModel,
                 disableOrderHistoryTab: disableOrderHistoryTab,
+                showLinkedAccountsTab: showLinkedAccountsTab,
                 betaLanguage: betaLanguage
             });
 

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -37,15 +37,18 @@
                         selected: true,
                         expanded: true
                     },
-                    {
+                ];
+
+                if (view.options.showLinkedAccountsTab) {
+                    accountSettingsTabs.push({
                         name: 'accountsTabSections',
                         id: 'accounts-tab',
                         label: gettext('Linked Accounts'),
                         tabindex: -1,
                         selected: false,
                         expanded: false
-                    }
-                ];
+                    });
+                }
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({
                         name: 'ordersTabSections',

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -52,6 +52,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
     AccountSettingsFactory(
         fieldsData,
         ${ disable_order_history_tab | n, dump_js_escaped_json },
+        ${ show_linked_accounts_tab | n, dump_js_escaped_json },
         ordersHistoryData,
         authData,
         '${ password_reset_support_link | n, js_escaped_string }',

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -25,7 +25,8 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
-    should_redirect_to_order_history_microfrontend
+    should_redirect_to_order_history_microfrontend,
+    should_show_linked_accounts_tab
 )
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.edx_api_utils import get_edx_api_data
@@ -139,6 +140,7 @@ def account_settings_context(request):
         'show_dashboard_tabs': True,
         'order_history': user_orders,
         'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -25,6 +25,15 @@ def should_redirect_to_order_history_microfrontend():
     )
 
 
+def should_show_linked_accounts_tab():
+    '''Check if the the var `SHOW_LINKED_ACCOUNTS`
+        is defined in configuration helpers.
+    '''
+    return (
+        configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
+    )
+
+
 # .. toggle_name: account.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -26,12 +26,10 @@ def should_redirect_to_order_history_microfrontend():
 
 
 def should_show_linked_accounts_tab():
-    '''Check if the the var `SHOW_LINKED_ACCOUNTS`
+    """Check if the the var `SHOW_LINKED_ACCOUNTS`
         is defined in configuration helpers.
-    '''
-    return (
-        configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
-    )
+    """
+    return configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
 
 
 # .. toggle_name: account.redirect_to_microfrontend


### PR DESCRIPTION
# Description
This feature allows to control the tab linked_accounts in account settings to appear or not. Is controlled using `SHOW_LINKED_ACCOUNTS`

(cherry picked from commit 7d43718042414d4e736d1c225cb9008c363dfbd3) (cherry picked from commit 6fef8d1ca7efe1b87602a764a8cbe62c880f623b)

## Extra
 Pr based on previous application
https://github.com/eduNEXT/edx-platform/commit/6fef8d1ca7efe1b87602a764a8cbe62c880f623b

This also solves the problem with nelp mango theme.
Tested in my mango stackbuilder environment.

# Before
![2022-10-04_15-26](https://user-images.githubusercontent.com/51926076/193921045-4f5b699c-36fa-4528-bd57-3d6c97950764.png)

# After Mango
![2022-10-04_15-27](https://user-images.githubusercontent.com/51926076/193921094-fff80151-6791-4863-a0e2-14fe92b0bfb2.png)
![2022-10-04_15-28](https://user-images.githubusercontent.com/51926076/193921093-08fe2603-343b-4ba9-8b60-82b255f697bb.png)

![2022-10-04_15-28_1](https://user-images.githubusercontent.com/51926076/193921086-29e1d8e7-c9f1-4aab-a821-a570f76a3ea5.png)
