### PR TITLE
feat: Add setting DISABLE_ORDER_HISTORY_TAB

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -139,7 +139,10 @@ def account_settings_context(request):
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,
         'order_history': user_orders,
-        'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'disable_order_history_tab': (
+            configuration_helpers.get_value('DISABLE_ORDER_HISTORY_TAB', False)
+            or should_redirect_to_order_history_microfrontend()
+        ),
         'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)


### PR DESCRIPTION
## Description

This will add a setting that allows to hide the Order history tab  when the order history microfrontend is not available 

## Testing instructions

Add in settings  `DISABLE_ORDER_HISTORY_TAB = True`  to hide
**This only work when eox-tenant is active** 

**Before**
![image](https://user-images.githubusercontent.com/36200299/197843428-0644c86f-28b7-4386-a931-dcdc931f300c.png)

**After**
![image](https://user-images.githubusercontent.com/36200299/197843533-0d38f425-fdb9-4213-bbc4-f9f2d312c134.png)

