### PR TITLE
feat(LD-9): tenant aware links from studio to the LMS

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -104,7 +104,7 @@ def _remove_instructors(course_key):
         log.error(f"Error in deleting course groups for {course_key}: {err}")
 
 
-def get_lms_link_for_item(location, preview=False):
+def get_lms_link_for_item(location, preview=False):  # pylint: disable=unused-argument
     """
     Returns an LMS link to the course with a jump_to to the provided location.
 
@@ -123,15 +123,6 @@ def get_lms_link_for_item(location, preview=False):
 
     if lms_base is None:
         return None
-
-    if preview:
-        # checks PREVIEW_LMS_BASE value in site configuration for the given course_org_filter(org)
-        # if not found returns settings.FEATURES.get('PREVIEW_LMS_BASE')
-        lms_base = SiteConfiguration.get_value_for_org(
-            location.org,
-            "PREVIEW_LMS_BASE",
-            settings.FEATURES.get('PREVIEW_LMS_BASE')
-        )
 
     return "//{lms_base}/courses/{course_key}/jump_to/{location}".format(
         lms_base=lms_base,

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -593,7 +593,12 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    external_url = urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url)
+    lms_root = configuration_helpers.get_value_for_org(
+        location.org,
+        'LMS_ROOT_URL',
+        settings.LMS_ROOT_URL
+    )
+    external_url = urljoin(lms_root, asset_url)
     return {
         'display_name': display_name,
         'content_type': content_type,

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -138,7 +138,7 @@ from openedx.core.djangolib.markup import HTML, Text
                             <span class="action-button-text">${_("View Live Version")}</span>
                         </a>
                     </li>
-                    <li class="action-item action-preview nav-item">
+                    <li class="action-item action-preview nav-item" style="display: none">
                         <a href="${draft_preview_link}" class="button button-preview action-button" rel="external" title="${_('Preview the courseware in the LMS')}">
                             <span class="action-button-text">${_("Preview")}</span>
                         </a>

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -54,8 +54,14 @@ def get_link_for_about_page(course):
     elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
+        about_base = configuration_helpers.get_value_for_org(
+            course.id.org,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
+
         course_about_url = '{about_base_url}/courses/{course_key}/about'.format(
-            about_base_url=configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            about_base_url=about_base,
             course_key=str(course.id),
         )
 


### PR DESCRIPTION
# Microsite aware links from studio to the LMS


## Description
This PR makes a backport to LD-9 feature to nutmeg
Backported commit https://github.com/eduNEXT/edunext-platform/commit/52c2855f92

## Supporting information
[JIRA Issue](https://edunext.atlassian.net/browse/DS-298)

## Testing instructions
1. if you are using stack builder

```yml
DOCKER_IMAGE_OPENEDX_DEV: docker.io/ednxops/distro-edunext-edxapp-dev:nuez
DOCKER_IMAGE_OPENEDX: docker.io/ednxops/distro-edunext-edxapp:nuez
EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edunext-platform.git
DISTRO_DISABLE_MFE: true
EDX_PLATFORM_VERSION: ednx-release/nuez.master
CMS_HOST: studio.nutmeg.edunext.link
LMS_HOST: lms.nutmeg.edunext.link
STRAIN_EXTRA_COMMANDS:
  - APP: "tutor"
    COMMAND: "distro enable-themes"
STRAIN_TUTOR_PLUGINS:
  - REPO: tutor-contrib-edunext-distro
    VERSION: v3.0.0
    EGG: tutor-contrib-edunext-distro==v3.0.0
    PACKAGE_NAME: distro
    PROTOCOL: ssh
DISTRO_THEMES_NAME:
  - bragi
STRAIN_VOLUME_OVERRIDES:
  edxapp:
    - DESTINATION: ../../src/edxapp/edx-platform
      LOCATION: /openedx/edx-platform
STRAIN_EXPORT_VOLUMES:
  - CONTAINER: lms
    LOCATION: /openedx/edx-platform
    DESTINATION: src/edxapp/edx-platform
```
2. `stack strain dev configure`
3. `stack strain dev init`
4. Checkout `nu/ednx/LD-9` branch in edx-platform code
4. Follow the [document instructions ](https://docs.google.com/document/d/1lWlC1_xqO308oHNH0F4fOdyV3uBlVte0wQC6UOa_3SE/edit#heading=h.dpnj47g0ew2e)
