### PR TITLE
style(pylint): organize lru_cache import

### DIFF
--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -10,6 +10,7 @@ import os
 import re
 from logging import getLogger
 
+from functools import lru_cache
 import crum
 from django.conf import settings
 
@@ -23,7 +24,6 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked
 )
 from openedx.core.lib.cache_utils import request_cached
-from functools import lru_cache
 
 logger = getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/openedx/core/djangoapps/theming/helpers_dirs.py
+++ b/openedx/core/djangoapps/theming/helpers_dirs.py
@@ -6,8 +6,8 @@ as the discovery happens during the initial setup of Django settings.
 
 import os
 
-from path import Path
 from functools import lru_cache
+from path import Path
 
 
 def get_theme_base_dirs_from_settings(theme_base_dirs=None):


### PR DESCRIPTION
# organize lru_cache import

## Description

This PR organizes the lru_cache import according to pylint. 
More context in GitHub actions:
https://github.com/eduNEXT/edunext-platform/actions/runs/3364873121/jobs/5579727303#step:8:12
