### PR TITLE
(FFI-3/DS-300) Add filter user's course enrollment

### DIFF
--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -29,6 +29,8 @@ from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.mobile_api.utils import API_V1, API_V05
 from openedx.features.course_duration_limits.access import check_course_expired
+# eduNEXT custom import to use filter with eox-tenant pipeline.
+from openedx.core.djangoapps.enrollments.data import CourseEnrollmentSiteFilterRequested
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.modulestore.exceptions import ItemNotFoundError  # lint-amnesty, pylint: disable=wrong-import-order
 
@@ -339,6 +341,11 @@ class UserCourseEnrollmentsList(generics.ListAPIView):
             is_active=True
         ).order_by('created').reverse()
         org = self.request.query_params.get('org', None)
+
+        # Custom filter to use with eox-tenant pipeline.
+        ## .. filter_implemented_name: CourseEnrollmentSiteFilterRequested
+        ## .. filter_type: org.openedx.learning.course_enrollments_site.filter.requested.v1
+        enrollments = CourseEnrollmentSiteFilterRequested.run_filter(context=enrollments)
 
         same_org = (
             enrollment for enrollment in enrollments


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds a filter connection to use a custom filter when we try to make a GET request in:
- http://{base_site_lms}/api/enrollment/v1/enrollment
- http://{base_site_lms}/api/mobile/v1/users/{username}/course_enrollments/

Using a custom pipeline filter that is implemented on eox-tenant, we can filter the course enrollments where a user is enrolled, but it only will show the courses from we make the request, what it means in the tenant site at that moment.

## Supporting information

This feature don't have dependencies from eox-tenant Django plugin, but in this PR the custom pipeline filter is implemented to test the functionality:
- https://github.com/eduNEXT/eox-tenant/pull/156

## Testing instructions

The change can be tested as a part of testing the [eox-tenant plugin](https://github.com/eduNEXT/eox-tenant/pull/156)

## Deadline

"None"

## Other information

There are two PRs that plan to add this feature in ``openedx/edx-platform`` and ``openedx-filters``
- ``[WIP]``openedx/edx-platform (The only thing that have different from this PR is ``CourseEnrollmentSiteFilterRequested`` class is not added because it is implemented in openedx-filters PR)
- https://github.com/openedx/openedx-filters/pull/47
