### PR TITLE
feat(LC-V2/DS-306): lang selector 

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -86,9 +86,10 @@ class DarkLangMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """
-        Prevent user from requesting un-released languages except by using the preview-lang query string.
+        eduNEXT: this middleware will always process the requests.
+        The model has been modified to not even attempt the db lookup
         """
-        if not DarkLangConfig.current().enabled:
+        if not settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False) and not DarkLangConfig.current().enabled:
             return
 
         self._clean_accept_headers(request)
@@ -137,8 +138,13 @@ class DarkLangMiddleware(MiddlewareMixin):
         Remove any language that is not either in ``self.released_langs`` or
         a territory of one of those languages.
         """
+        ednx_locale = settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False)
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', None)
         if accept is None or accept == '*':
+            if ednx_locale:
+                # eduNEXT: return the site aware settings.LANGUAGE_CODE
+                # so that django.utils.locale.LocaleMiddleware can pick it up
+                request.META['HTTP_ACCEPT_LANGUAGE'] = f"{settings.LANGUAGE_CODE};q=0.1"
             return
 
         new_accept = []
@@ -147,6 +153,9 @@ class DarkLangMiddleware(MiddlewareMixin):
             if fuzzy_code:
                 # Formats lang and priority into a valid accept header fragment.
                 new_accept.append(f"{fuzzy_code};q={priority}")
+            elif ednx_locale:
+                # eduNEXT: if there is no match, we set it to the settings.LANGUAGE_CODE
+                new_accept.append(f"{settings.LANGUAGE_CODE};q=0.1")
 
         new_accept = ", ".join(new_accept)
 

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -4,6 +4,7 @@ Models for the dark-launching languages
 
 
 from config_models.models import ConfigurationModel
+from django.conf import settings
 from django.db import models
 
 
@@ -35,13 +36,19 @@ class DarkLangConfig(ConfigurationModel):
         ``released_languages`` as a list of language codes.
 
         Example: ['it', 'de-at', 'es', 'pt-br']
-        """
-        if not self.released_languages.strip():
-            return []
 
-        languages = [lang.lower().strip() for lang in self.released_languages.split(',')]
+        eduNEXT: we support only the list of available languages from the site
+        otherwise is the same as having no configuration
+        """
+        released_languages = self.released_languages
+
+        if settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
+            released_languages = getattr(settings, "released_languages", "")
+
+        languages = [lang.lower().strip() for lang in released_languages.split(',')]
         # Put in alphabetical order
         languages.sort()
+
         return languages
 
     @property


### PR DESCRIPTION
## Description
This feature does a match between the languages that the user accepts -on their browser- and the languages available on this tenant. Ednxsite awareness for language selection. It replaces the regular DarkLang app with a ednxsite aware configuration.

Update openedx/core/djangoapps/dark_lang/models.py

## Testing instructions

To test this you can follow the intructions in [this document](https://docs.google.com/document/d/1EO5aDX8CrsDRwdlqtu-VE5SduQmQ3xYLpShfOdhXYqQ/edit#)

## Other information
[JIRA-CARD](https://edunext.atlassian.net/browse/DS-306)
