### PR TITLE
feat(LI-13/DS-315): allow non-staff user create honor course modes

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -30,7 +30,8 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.utils.translation import gettext as _
+from django.urls import reverse
+from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 from eventtracking import tracker
@@ -400,19 +401,28 @@ def certificates_list_handler(request, course_key_string):
                 handler_name='certificate_activation_handler',
                 course_key=course_key
             )
+            course_mode_creation_url = reverse(
+                'course_modes_api:v1:course_modes_list',
+                args=(str(course_key),),
+            )
             course_modes = [
                 mode.slug for mode in CourseMode.modes_for_course(
                     course_id=course.id, include_expired=True
                 ) if mode.slug != 'audit'
             ]
+            # Check whether the audit mode associated with the course exists in database
+            has_audit_mode = CourseMode.objects.filter(course_id=course.id, mode_slug='audit')
 
             has_certificate_modes = len(course_modes) > 0
+
+            enable_course_mode_creation = settings.FEATURES.get('ENABLE_COURSE_MODE_CREATION', False)
 
             if has_certificate_modes:
                 certificate_web_view_url = get_lms_link_for_certificate_web_view(
                     course_key=course_key,
                     mode=course_modes[0]  # CourseMode.modes_for_course returns default mode if doesn't find anyone.
                 )
+                enable_course_mode_creation = False
             else:
                 certificate_web_view_url = None
             is_active, certificates = CertificateManager.is_activated(course)
@@ -420,6 +430,9 @@ def certificates_list_handler(request, course_key_string):
                 'context_course': course,
                 'certificate_url': certificate_url,
                 'course_outline_url': course_outline_url,
+                'course_mode_creation_url': course_mode_creation_url,
+                'enable_course_mode_creation': enable_course_mode_creation and not has_audit_mode,
+                'course_id': str(course_key),
                 'upload_asset_url': upload_asset_url,
                 'certificates': certificates,
                 'has_certificate_modes': has_certificate_modes,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -501,6 +501,18 @@ FEATURES = {
     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
     #   in the LMS and CMS.
     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+    # .. toggle_name: ENABLE_COURSE_MODE_CREATION
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable course mode creation through studio.
+    # .. toggle_category: n/a
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-06-21
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/eduNEXT/edunext-platform/pull/524
+    # .. toggle_status: supported
+    'ENABLE_COURSE_MODE_CREATION': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/cms/static/cms/js/build.js
+++ b/cms/static/cms/js/build.js
@@ -24,6 +24,7 @@
             'js/factories/export',
             'js/factories/group_configurations',
             'js/certificates/factories/certificates_page_factory',
+            'js/certificates/factories/course_mode_factory',
             'js/factories/index',
             'js/factories/manage_users',
             'js/factories/outline',

--- a/cms/static/cms/js/spec/main.js
+++ b/cms/static/cms/js/spec/main.js
@@ -280,7 +280,8 @@
         'js/certificates/spec/views/certificate_details_spec',
         'js/certificates/spec/views/certificate_editor_spec',
         'js/certificates/spec/views/certificates_list_spec',
-        'js/certificates/spec/views/certificate_preview_spec'
+        'js/certificates/spec/views/certificate_preview_spec',
+        'js/certificates/spec/views/add_course_mode_spec'
     ];
 
     i = 0;

--- a/cms/static/js/certificates/factories/course_mode_factory.js
+++ b/cms/static/js/certificates/factories/course_mode_factory.js
@@ -1,0 +1,15 @@
+define([
+    'jquery',
+    'js/certificates/views/add_course_mode'
+],
+function($, CourseModeHandler) {
+    'use strict';
+    return function(enableCourseModeCreation, courseModeCreationUrl, courseId) {
+        // Execute the page object's rendering workflow
+        new CourseModeHandler({
+            enableCourseModeCreation: enableCourseModeCreation,
+            courseModeCreationUrl: courseModeCreationUrl,
+            courseId: courseId
+        }).show();
+    };
+});

--- a/cms/static/js/certificates/spec/views/add_course_mode_spec.js
+++ b/cms/static/js/certificates/spec/views/add_course_mode_spec.js
@@ -1,0 +1,89 @@
+// Jasmine Test Suite: Course modes creation
+
+define([
+    'underscore',
+    'jquery',
+    'js/models/course',
+    'js/certificates/views/add_course_mode',
+    'common/js/spec_helpers/template_helpers',
+    'common/js/spec_helpers/view_helpers',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
+],
+function(_, $, Course, AddCourseMode, TemplateHelpers, ViewHelpers, AjaxHelpers) {
+    'use strict';
+
+    var SELECTORS = {
+        addCourseMode: '.add-course-mode'
+    };
+
+    describe('Add Course Modes Spec:', function() {
+        beforeEach(function() {
+            window.course = new Course({
+                id: '5',
+                name: 'Course Name',
+                url_name: 'course_name',
+                org: 'course_org',
+                num: 'course_num',
+                revision: 'course_rev'
+            });
+            window.CMS.User = {isGlobalStaff: true, isCourseInstructor: true};
+
+            TemplateHelpers.installTemplate('course-modes', true);
+            appendSetFixtures('<div class="wrapper-certificates nav-actions"></div>');
+            appendSetFixtures('<p class="account-username">test</p>');
+            this.view = new AddCourseMode({
+                el: $('.wrapper-certificates'),
+                courseId: window.course.id,
+                courseModeCreationUrl: '/api/course_modes/v1/courses/' + window.course.id + '/',
+                enableCourseModeCreation: true
+            });
+            appendSetFixtures(this.view.render().el);
+        });
+
+        afterEach(function() {
+            delete window.course;
+            delete window.CMS.User;
+        });
+
+        describe('Add course modes', function() {
+            it('course mode creation event works fine', function() {
+                spyOn(this.view, 'addCourseMode');
+                this.view.delegateEvents();
+                this.view.$(SELECTORS.addCourseMode).click();
+                expect(this.view.addCourseMode).toHaveBeenCalled();
+            });
+
+            it('add course modes button works fine', function() {
+                var requests = AjaxHelpers.requests(this),
+                    notificationSpy = ViewHelpers.createNotificationSpy();
+                this.view.$(SELECTORS.addCourseMode).click();
+                AjaxHelpers.expectJsonRequest(
+                    requests,
+                    'POST', '/api/course_modes/v1/courses/' + window.course.id + '/?username=test',
+                    {
+                        course_id: window.course.id,
+                        mode_slug: 'honor',
+                        mode_display_name: 'Honor',
+                        currency: 'usd'
+                    });
+                ViewHelpers.verifyNotificationShowing(notificationSpy, /Enabling honor course mode/);
+            });
+
+            it('enable course mode creation should be false when method "remove" called', function() {
+                this.view.remove();
+                expect(this.view.enableCourseModeCreation).toBe(false);
+            });
+
+            it('add course mode should be removed when method "remove" called', function() {
+                this.view.remove();
+                expect(this.view.el.innerHTML).toBe('');
+            });
+
+            it('method "show" should call the render function', function() {
+                spyOn(this.view, 'render');
+                this.view.show();
+                expect(this.view.render).toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/cms/static/js/certificates/views/add_course_mode.js
+++ b/cms/static/js/certificates/views/add_course_mode.js
@@ -1,0 +1,70 @@
+define([
+    'underscore',
+    'gettext',
+    'js/views/baseview',
+    'common/js/components/views/feedback_notification',
+    'text!templates/course-modes.underscore',
+    'edx-ui-toolkit/js/utils/html-utils'
+],
+function(_, gettext, BaseView, NotificationView, CourseModes, HtmlUtils) {
+    'use strict';
+
+    var AddCourseMode = BaseView.extend({
+        el: $('.wrapper-certificates'),
+        events: {
+            'click .add-course-mode': 'addCourseMode'
+        },
+
+        initialize: function(options) {
+            this.enableCourseModeCreation = options.enableCourseModeCreation;
+            this.courseModeCreationUrl = options.courseModeCreationUrl;
+            this.courseId = options.courseId;
+        },
+
+        render: function() {
+            HtmlUtils.setHtml(this.$el, HtmlUtils.template(CourseModes)({
+                enableCourseModeCreation: this.enableCourseModeCreation,
+                courseModeCreationUrl: this.courseModeCreationUrl,
+                courseId: this.courseId
+            }));
+            return this;
+        },
+
+        addCourseMode: function() {
+            var notification = new NotificationView.Mini({
+                title: gettext('Enabling honor course mode')
+            });
+            var username = $('.account-username')[0].innerText;
+            $.ajax({
+                url: this.courseModeCreationUrl + '?username=' + username,
+                dataType: 'json',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    course_id: this.courseId,
+                    mode_slug: 'honor',
+                    mode_display_name: 'Honor',
+                    currency: 'usd'
+                }),
+                type: 'POST',
+                beforeSend: function() {
+                    notification.show();
+                },
+                success: function() {
+                    notification.hide();
+                    location.reload();
+                }
+            });
+        },
+
+        show: function() {
+            this.render();
+        },
+
+        remove: function() {
+            this.enableCourseModeCreation = false;
+            this.$el.empty();
+            return this;
+        }
+    });
+    return AddCourseMode;
+});

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -17,7 +17,7 @@ from six.moves.urllib.parse import quote
 <%block name="bodyclass">is-signedin course view-certificates</%block>
 
 <%block name="header_extras">
-% for template_name in ["certificate-details", "certificate-editor", "signatory-editor", "signatory-details", "basic-modal", "modal-button", "list", "upload-dialog", "certificate-web-preview", "signatory-actions"]:
+% for template_name in ["certificate-details", "certificate-editor", "signatory-editor", "signatory-details", "basic-modal", "modal-button", "list", "upload-dialog", "certificate-web-preview", "signatory-actions", "course-modes"]:
   <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
   </script>
@@ -45,6 +45,15 @@ CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? t
           ${certificate_web_view_url | n, dump_js_escaped_json},
           ${is_active | n, dump_js_escaped_json},
           ${certificate_activation_handler_url | n, dump_js_escaped_json}
+      );
+  });
+% endif
+% if enable_course_mode_creation:
+  require(["js/certificates/factories/course_mode_factory"], function(CourseModeFactory) {
+    CourseModeFactory(
+          ${enable_course_mode_creation | n, dump_js_escaped_json},
+          ${course_mode_creation_url | n, dump_js_escaped_json},
+          ${course_id | n, dump_js_escaped_json}
       );
   });
 % endif

--- a/cms/templates/js/course-modes.underscore
+++ b/cms/templates/js/course-modes.underscore
@@ -1,0 +1,6 @@
+<div class="no-content">
+<label for="add-course-mode"><%- gettext("Enable the honor mode for the course.") %></label>
+<a href="#" class="button new-button add-course-mode">
+    <% if ( enableCourseModeCreation ) { %> <%- gettext("Enable honor mode") %> <% } %>
+</a>
+</div>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -183,6 +183,15 @@ urlpatterns = oauth2_urlpatterns + [
     path('api/val/v0/', include('edxval.urls')),
     path('api/tasks/v0/', include('user_tasks.urls')),
     path('accessibility', contentstore_views.accessibility, name='accessibility'),
+
+    # Course modes API for certificates generation
+    path(
+        r'^api/course_modes/',
+        include(
+            ('common.djangoapps.course_modes.rest_api.urls', 'common.djangoapps.course_mods'),
+            namespace='course_modes_api',
+        )
+    ),
 ]
 
 if not settings.DISABLE_DEPRECATED_SIGNIN_URL:

--- a/common/djangoapps/course_modes/rest_api/serializers.py
+++ b/common/djangoapps/course_modes/rest_api/serializers.py
@@ -4,6 +4,7 @@ Course modes API serializers.
 
 
 from rest_framework import serializers
+from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.models import CourseMode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -39,7 +40,8 @@ class CourseModeSerializer(serializers.Serializer):
         ListCreateAPIView.
         """
         if 'course_id' in validated_data:
-            course_overview = CourseOverview.get_from_id(validated_data['course_id'])
+            course_id = CourseKey.from_string(validated_data['course_id'])
+            course_overview = CourseOverview.get_from_id(course_id)
             del validated_data['course_id']
             validated_data['course'] = course_overview
 

--- a/webpack-config/file-lists.js
+++ b/webpack-config/file-lists.js
@@ -26,6 +26,7 @@ module.exports = {
         path.resolve(__dirname, '../cms/static/js/certificates/views/certificate_preview.js'),
         path.resolve(__dirname, '../cms/static/js/certificates/views/signatory_details.js'),
         path.resolve(__dirname, '../cms/static/js/certificates/views/signatory_editor.js'),
+        path.resolve(__dirname, '../cms/static/js/certificates/views/add_course_mode.js'),
         path.resolve(__dirname, '../cms/static/js/views/active_video_upload_list.js'),
         path.resolve(__dirname, '../cms/static/js/views/assets.js'),
         path.resolve(__dirname, '../cms/static/js/views/course_video_settings.js'),


### PR DESCRIPTION
## Description
This PR adds the necessary components to create course modes through Studio. This version just creates the Honor course mode, that's one of the requirements to start generating certificates.

## Commits considered
  previus PR: https://github.com/eduNEXT/edunext-platform/pull/600
  upstream: https://github.com/openedx/edx-platform/pull/28114

## How to test

1. Update statics: `tutor dev run lms openedx-assets build --env=dev`
2. Turn on the feature: 
`'ENABLE_COURSE_MODE_CREATION': True,`

You can do it in: env/apps/openedx/settings/cms/development.py
`FEATURES["ENABLE_COURSE_MODE_CREATION"] = True`

3. Go to Studio > Certificates

![image](https://user-images.githubusercontent.com/39854568/203629148-e91c8294-38ff-4b79-b6ee-80195a8bef2f.png)

4. Enable course mode
![image](https://user-images.githubusercontent.com/39854568/203631585-38140fb4-f557-4111-b63e-3a51b4f9f2bc.png)

5. Go to django-admin and check for honor course mode for the course 
![image](https://user-images.githubusercontent.com/39854568/203631600-8e3eae27-321d-4061-b0e5-17c5688c4d1a.png)
