### PR TITLE
feat(JU-10/DS-308): Comment log in migration file

### DIFF
--- a/lms/djangoapps/courseware/migrations/0008_move_idde_to_edx_when.py
+++ b/lms/djangoapps/courseware/migrations/0008_move_idde_to_edx_when.py
@@ -2,7 +2,6 @@
 
 
 import json
-import logging
 
 from django.db import migrations
 
@@ -12,7 +11,6 @@ def move_overrides_to_edx_when(apps, schema_editor):
     from edx_when import api
     date_field = Date()
     StudentFieldOverride = apps.get_model('courseware', 'StudentFieldOverride')
-    log = logging.getLogger(__name__)
     for override in StudentFieldOverride.objects.filter(field='due'):
         try:
             abs_date = date_field.from_json(json.loads(override.value))
@@ -23,7 +21,10 @@ def move_overrides_to_edx_when(apps, schema_editor):
                 abs_date,
                 user=override.student)
         except Exception:  # pylint: disable=broad-except
-            log.exception("migrating %d %r: %r", override.id, override.location, override.value)
+            # The following line is commented since these logs only add noise to output console
+            # Thi migration only works with IDDE
+            # log.exception("migrating %d %r: %r", override.id, override.location, override.value)
+            pass
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -5,6 +5,7 @@ Classes that override default django-oauth-toolkit behavior
 
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -80,6 +81,11 @@ class EdxOAuth2Validator(OAuth2Validator):
             # Ensure the tokens get associated with the correct user since DOT does not normally
             # associate access tokens issued with the client_credentials grant to users.
             request.user = request.client.user
+
+            # ednx: JU-10. Tokens for the machine-to-machine comunication should be longer lived
+            #       for backwards compatibility with eox-core and other plugin APIs.
+            #       Without this modification the BearerToken class will set this to 3600
+            request.expires_in = getattr(settings, 'CLIENT_CREDENTIALS_ACCESS_TOKEN_EXPIRE_SECONDS', 31557600)
 
         super().save_bearer_token(token, request, *args, **kwargs)
 


### PR DESCRIPTION
This PR add long duration token to nuez. Here are the steps to try it:

1. In a new folder touch a `strain.yml` file with the following content:
```
STRAIN_NAME: nuezdistro
STRAIN_TUTOR_VERSION: v14.1.0
DOCKER_IMAGE_OPENEDX_DEV: docker.io/ednxops/distro-edunext-edxapp-dev:nuez
DOCKER_IMAGE_OPENEDX: docker.io/ednxops/distro-edunext-edxapp:nuez
EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edunext-platform.git
EDX_PLATFORM_VERSION: nu/ednx/JU-10
CMS_HOST: studio.nutmeg.edunext.link
LMS_HOST: lms.nutmeg.edunext.link
DEV_PROJECT_NAME: nuezdistro_dev
LOCAL_PROJECT_NAME: nuezdistro_local
PLATFORM_NAME: Nuez
STRAIN_TUTOR_PLUGINS:
  - REPO: tutor-contrib-edunext-distro
    VERSION: v3.0.0
    EGG: tutor-contrib-edunext-distro==v3.0.0
    PACKAGE_NAME: distro
    PROTOCOL: ssh
STRAIN_EXTRA_COMMANDS:
  - APP: 'tutor'
    COMMAND: 'distro enable-themes'
STRAIN_VOLUME_OVERRIDES:
  edxapp:
    - DESTINATION: ../../src/edxapp/edx-platform
      LOCATION: /openedx/edx-platform
STRAIN_EXPORT_VOLUMES:
  - CONTAINER: lms
    LOCATION: /openedx/edx-platform
    DESTINATION: src/edxapp/edx-platform
DISTRO_THEMES_NAME:
  - bragi
```
2. Use the following commands:
```
stack strain create
source .tvm/bin/activate
stack strain dev configure -k override_vols -k export_vols
stack strain dev init
stack strain dev configure -s override_vols -k export_vols
```
3. Create an admin user with the following command: `tutor dev createuser --staff --superuser admin admin@edunext.co -p password`. 
4. In the Django admin, go to Django OAuth Toolkit > Applications > Add Application. 
-  Write down both the _client_id_ and the _client_secret_.
-  Make sure you pick the admin's id you created in step 3.
-  On redirect urls write the url you environment is using keeping in mind if you're using any tenant.
-  At client type pick Confidential.
-  Choose client credentials at Authorization grant types.
-  Write any random name you want.
-  Lastly, make sure you thick the Slip authorization checkbox.
5. From here there are two ways to test:
- Terminal: Copy, paste, and replace where needed the following code:
```
curl --location --request POST 'http://<YOUR-URL>/oauth2/access_token' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'client_id=<YOUR-CLIENT-ID>' \
--data-urlencode 'client_secret=<YOUR-CLIENT-SECRET>' \
--data-urlencode 'grant_type=client_credentials'
```
You should get something like this:
```
{
  "access_token": "7wjnmhIHC3B67EvNDVD0xo68kwVQJy", 
  "expires_in": 31557600, 
  "token_type": "Bearer", 
  "scope": "read write email profile"
}
```
- Postman or such tool: Go to the [documentation](https://docs.google.com/document/d/14Q9rp23m4c7_WzaJqBs0CPhqCJlQS6Ncci0Ll76WJ7o/edit)