### PR TITLE
feat: Add email field to UserMappingView

### DIFF
--- a/common/djangoapps/third_party_auth/api/serializers.py
+++ b/common/djangoapps/third_party_auth/api/serializers.py
@@ -9,6 +9,7 @@ class UserMappingSerializer(serializers.Serializer):  # pylint: disable=abstract
     provider = None
     username = serializers.SerializerMethodField()
     remote_id = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         self.provider = kwargs['context'].get('provider', None)
@@ -21,3 +22,7 @@ class UserMappingSerializer(serializers.Serializer):  # pylint: disable=abstract
     def get_remote_id(self, social_user):
         """ Gets remote id from social user based on provider """
         return self.provider.get_remote_id_from_social_auth(social_user)
+
+    def get_email(self, social_user):
+        """ Gets the edx email from a social user """
+        return social_user.user.email

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -334,6 +334,8 @@ class UserMappingView(ListAPIView):
             * username: The edx username
 
             * remote_id: The Id from third party auth provider
+
+            * email: The edx email
     """
     authentication_classes = (JwtAuthentication, BearerAuthentication, )
     permission_classes = (TPA_PERMISSIONS, )


### PR DESCRIPTION
## Description

This will add the email field in the API response, this is necessary since the client needs to know the email value in order to use it in another process 

## Note
This is required to test subscription workflow in stage, and depends on the client's decision to move to production 

## Testing instructions

- Get jwt token in /oauth2/access_token/
- Set Authorization header with the previous token and make a request to  /api/third_party_auth/v0/providers/< provider-id >/users provider-id is the slug plus the backend prefix, for example   saml-default-slug the slug can be found in /admin/third_party_auth/samlproviderconfig/
