### PR TITLE
feat(LI-1/DS-309): Remove edX branding on account deletion

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -5091,3 +5091,5 @@ DISCUSSION_MODERATION_CLOSE_REASON_CODES = {
     "duplicate": _("Post is a duplicate"),
     "off-topic": _("Post is off-topic"),
 }
+#################### DELETION TEXT ###########################
+SITE_SPECIFIC_DELETION_TEXT = ''

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -114,16 +114,8 @@ export class StudentAccountDeletion extends React.Component {
               <span>{bodyDeletion2}</span>
         </p>
         <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: loseAccessText }}
-        />
-        <p
           className="account-settings-header-subtitle-warning"
           dangerouslySetInnerHTML={{ __html: acctDeletionWarningText }}
-        />
-        <p
-          className="account-settings-header-subtitle"
-          dangerouslySetInnerHTML={{ __html: changeAcctInfoText }}
         />
         <Button
           id="delete-account-btn"

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -165,7 +165,6 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                         <span>{bodyDeletion} </span>
                         <span>{bodyDeletion2}</span>
                       </p>
-                      <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Description:
To maintain the eduNEXT brand when account deletion deleted some refs to openedx.

## Last PR:

https://github.com/eduNEXT/edunext-platform/pull/597

## How to test

1. In this branch compile assets with `tutor dev run lms openedx-assets build --env=dev`

2. Go to account settings > delete-account section, you should view something like this:

![image](https://user-images.githubusercontent.com/39854568/203874367-a638dd60-ab22-400f-8b30-5c2540d4942f.png)

BEFORE:

![image](https://user-images.githubusercontent.com/39854568/203874556-2e02cc3d-b4b0-4d99-9f12-cea8efb0578f.png)



