### PR TITLE
feat: Allow to include translations for extended profile fields

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -23,6 +23,7 @@ from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import all_languages, released_languages
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
     should_redirect_to_order_history_microfrontend,
@@ -250,6 +251,13 @@ def _get_extended_profile_fields():
         "profession": _("Profession"),
         "specialty": _("Specialty")
     }
+    request = theming_helpers.get_current_request()
+    extended_profile_fields_translations = configuration_helpers.get_value(
+        'extended_profile_fields_translations',
+        {},
+    )
+    translations = extended_profile_fields_translations.get(request.LANGUAGE_CODE, {})
+    field_labels_map.update(translations)
 
     extended_profile_field_names = configuration_helpers.get_value('extended_profile_fields', [])
     for field_to_exclude in fields_already_showing:


### PR DESCRIPTION
## Description
These changes allow to set labels for extended profile fields in order to include translations 

## Testing instructions
1. set extended profile fields in your tenant config, example 
```
    "extended_profile_fields": [
        "hobby",
        "sport",
        "movie"
    ]
```
2. Set extended profile field translations, example
```
    "extended_profile_fields_translations": {
        "ar": {
            "hobby": "\u0647\u0648\u0627\u064a\u0629"
        }
    },
```
The `extended_profile_fields_translations` must be a dictionary with language code keys and every language code key is a dictionary that must include the field that will be translated where the key is the field name and the value is the translation

3. go to /account/settings and change the language if it is necessary 

## Results in local
just the field `hobby` was set 

EN
![image](https://user-images.githubusercontent.com/36200299/204052276-19da334c-f8ca-4cb1-a112-5ad5c1aaa513.png)


AR
![image](https://user-images.githubusercontent.com/36200299/204052260-052e748e-a9a0-4cca-829b-d6e3010d2ad2.png)

