### PR TITLE
fix: update xblock-drag-and-drop for a high level security alert

### DIFF
--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -18,8 +18,15 @@
 
 
 # using LTS django version
-
+Django<4.0
 
 # elasticsearch>=7.14.0 includes breaking changes in it which caused issues in discovery upgrade process.
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
+
+# setuptools==60.0 had breaking changes and busted several service's pipeline.
+# Details can be found here: https://github.com/pypa/setuptools/issues/2940
+setuptools<60
+
+# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
+django-simple-history==3.0.0

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -53,6 +53,7 @@ networkx==2.2
     #   -r requirements/edx-sandbox/py35.in
 nltk==3.6.2
     # via
+    #   -c requirements/edx-sandbox/py35-constraints.txt
     #   -r requirements/edx-sandbox/py35.in
     #   chem
 numpy==1.16.5

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -149,9 +149,7 @@ cryptography==35.0.0
 cssutils==2.3.0
     # via pynliner
 ddt==1.4.4
-    # via
-    #   xblock-drag-and-drop-v2
-    #   xblock-poll
+    # via xblock-poll
 defusedxml==0.7.1
     # via
     #   -r requirements/edx/base.in
@@ -165,6 +163,7 @@ deprecated==1.2.13
     # via jwcrypto
 django==3.2.13
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   django-appconf
@@ -327,6 +326,7 @@ django-ses==2.3.0
     # via -r requirements/edx/base.in
 django-simple-history==3.0.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.in
     #   edx-enterprise
     #   edx-organizations
@@ -641,7 +641,6 @@ maxminddb==2.2.0
 mock==4.0.3
     # via
     #   -r requirements/edx/paver.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/github.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1056,7 +1056,7 @@ xblock==1.5.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v3.0.0
     # via -r requirements/edx/github.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
     # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -220,7 +220,6 @@ cssutils==2.3.0
 ddt==1.4.4
     # via
     #   -r requirements/edx/testing.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 defusedxml==0.7.1
     # via
@@ -245,6 +244,7 @@ distlib==0.3.3
     #   virtualenv
 django==3.2.13
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   django-appconf
@@ -420,6 +420,7 @@ django-ses==2.3.0
     # via -r requirements/edx/testing.txt
 django-simple-history==3.0.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-enterprise
     #   edx-organizations
@@ -865,7 +866,6 @@ mistune==0.8.4
 mock==4.0.3
     # via
     #   -r requirements/edx/testing.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1537,7 +1537,7 @@ xblock==1.5.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v3.0.0
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -74,4 +74,4 @@ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc32118
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v3.0.0#egg=xblock-drag-and-drop-v2==3.0.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -73,7 +73,6 @@ attrs==21.2.0
     #   aiohttp
     #   edx-ace
     #   openedx-events
-    #   outcome
     #   pytest
 babel==2.9.1
     # via
@@ -210,7 +209,6 @@ ddt==1.4.4
     # via
     #   -r requirements/edx/base.txt
     #   -r requirements/edx/testing.in
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 defusedxml==0.7.1
     # via
@@ -232,6 +230,7 @@ diff-cover==4.0.0
 distlib==0.3.3
     # via virtualenv
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   django-appconf
@@ -404,6 +403,7 @@ django-ses==2.3.0
     # via -r requirements/edx/base.txt
 django-simple-history==3.0.0
     # via
+    #   -c requirements/edx/../common_constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-enterprise
     #   edx-organizations
@@ -818,7 +818,6 @@ mccabe==0.6.1
 mock==4.0.3
     # via
     #   -r requirements/edx/base.txt
-    #   xblock-drag-and-drop-v2
     #   xblock-poll
 mongodbproxy @ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a
     # via -r requirements/edx/base.txt
@@ -1413,7 +1412,7 @@ xblock==1.5.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v3.0.0
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This pull request update xblock-drag-and-drop to the latest compatible version with maple (and nutmeg) that take care of the a security vulnerability reported in https://discuss.openedx.org/t/upcoming-security-release-xblock-drag-and-drop-v2/8768

## Deadline

This PR should be merged on Monday, November 28th, and the images for the following stratus clients should be rebuilt and deployed.