### PR TITLE
fix(LI-12/DS-312): Relax load in instructor dashboard.

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -119,7 +119,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         log.error("Unable to find course with course key %s while loading the Instructor Dashboard.", course_id)
         return HttpResponseServerError()
 
-    course = get_course_by_id(course_key, depth=0)
+    course = get_course_by_id(course_key, depth=None)
 
     access = {
         'admin': request.user.is_staff,


### PR DESCRIPTION
# Relax load in instructor dashboard.

## Description

Fix: Relax load on the instructor dashboard page.

This PR is based on the implementation of Jhony.
https://github.com/eduNEXT/edunext-platform/pull/519

And migration of Johan https://github.com/eduNEXT/edunext-platform/pull/605
In his PR you can check tests with performance.

Bringing all the course children when fetching a course in the instructor dashboard page.

## How to test

In this PR is not necessary do strict tests because this fix was merged in Olive https://github.com/openedx/edx-platform/pull/29687 and is just a backport 


