### PR TITLE
fix(IR-5/DS-311): prevent 500 error when course mode currency is not the same as the one configured in settings

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -774,7 +774,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        return min(
+            (mode.min_price for mode in modes if mode.currency.lower() == currency.lower()),
+            default=0
+        )
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -125,6 +125,11 @@ class CourseModeModelTest(TestCase):
         # no modes, should get 0
         assert 0 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
 
+        # with mode with other currency, should get 0
+        mode = Mode('audit', 'Audit', 30, '', 'eur', None, None, None, None)
+        self.create_mode(mode.slug, mode.name, mode.min_price, mode.suggested_prices, mode.currency)
+        assert 0 == CourseMode.min_course_price_for_currency(self.course_key, 'usd')
+
         # create some modes
         mode1 = Mode('honor', 'Honor Code Certificate', 10, '', 'usd', None, None, None, None)
         mode2 = Mode('verified', 'Verified Certificate', 20, '', 'usd', None, None, None, None)


### PR DESCRIPTION
Description
This PR solves the http 500 error when course concurrency is setted different for PAID_COURSE_REGISTRATION_CURRENCY and course modes.

Before:
![image](https://user-images.githubusercontent.com/39854568/204845420-54675b08-5342-4c2f-873c-f3370a7b725e.png)


After:
![image](https://user-images.githubusercontent.com/39854568/204845449-c0f4cb85-6186-4cf8-8d71-73a2564eb224.png)


This commit is backport from https://github.com/openedx/edx-platform/pull/31312