### PR TITLE
(LI-7/DS-310)Restrict access token by application allowed uris.

### DIFF
--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -84,7 +84,7 @@ class CcxRestApiTest(CcxTestCase, APITestCase):
             user=user,
             client_type='confidential',
             authorization_grant_type='authorization-code',
-            redirect_uris='http://localhost:8079/complete/edxorg/'
+            redirect_uris='http://localhost:8079/complete/edxorg/ http://testserver/'
         )
         # create an authorization code
         auth_oauth2_provider = dot_models.AccessToken.objects.create(

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -970,6 +970,9 @@ DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+####################### ALLOWED APPLICATIONS####################
+#The applications in this list won't be restricted by site.
+ALLOWED_AUTH_APPLICATIONS = ENV_TOKENS.get('ALLOWED_AUTH_APPLICATIONS', [])
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/factories.py
@@ -23,6 +23,7 @@ class ApplicationFactory(DjangoModelFactory):
     client_type = 'confidential'
     authorization_grant_type = Application.CLIENT_CONFIDENTIAL
     name = FuzzyText(prefix='name', length=8)
+    redirect_uris = 'http://testserver/'
 
 
 class ApplicationAccessFactory(DjangoModelFactory):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -30,7 +30,7 @@ class ClientCredentialsTest(mixins.AccessTokenMixin, TestCase):
             name='test dot application',
             user=self.user,
             authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-app-client-id',
         )
         scopes = ['read', 'write', 'email']

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -99,7 +99,7 @@ class CustomAuthorizationViewTestCase(TestCase):
         restricted_app = self.dot_adapter.create_confidential_client(
             name='test restricted dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-restricted-app-client-id',
         )
         models.RestrictedApplication.objects.create(application=restricted_app)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -89,7 +89,7 @@ class _DispatchingViewTestCase(TestCase):
         self.dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-app-client-id',
         )
 
@@ -103,7 +103,7 @@ class _DispatchingViewTestCase(TestCase):
         self.restricted_dot_app = self.dot_adapter.create_public_client(
             name='test restricted dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='dot-restricted-app-client-id',
         )
         models.RestrictedApplication.objects.create(application=self.restricted_dot_app)
@@ -308,7 +308,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         dot_app = self.dot_adapter.create_public_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id=f'dot-app-client-id-{grant_type}',
             grant_type=grant_type,
         )
@@ -372,7 +372,7 @@ class TestAuthorizationView(_DispatchingViewTestCase):
         self.dot_app = self.dot_adapter.create_confidential_client(
             name='test dot application',
             user=self.user,
-            redirect_uri=DUMMY_REDIRECT_URL,
+            redirect_uri=f'{DUMMY_REDIRECT_URL} http://testserver/',
             client_id='confidential-dot-app-client-id',
         )
         models.ApplicationAccess.objects.create(

--- a/openedx/core/djangoapps/user_authn/tests/utils.py
+++ b/openedx/core/djangoapps/user_authn/tests/utils.py
@@ -105,7 +105,7 @@ class AuthAndScopesTestMixin:
             user=dot_app_user,
             client_type='confidential',
             authorization_grant_type='authorization-code',
-            redirect_uris='http://localhost:8079/complete/edxorg/'
+            redirect_uris='http://localhost:8079/complete/edxorg/ http://testserver/'
         )
         return dot_models.AccessToken.objects.create(
             user=user,

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -72,7 +72,7 @@ class OAuth2AllowInActiveUsersTests(TestCase):  # lint-amnesty, pylint: disable=
             name='example',
             user=self.user,
             client_id='dot-client-id',
-            redirect_uri='https://example.edx/redirect',
+            redirect_uri='https://example.edx/redirect http://testserver/',
         )
         self.dot_access_token = dot_models.AccessToken.objects.create(
             user=self.user,
@@ -226,6 +226,29 @@ class BearerAuthenticationTests(OAuth2AllowInActiveUsersTests):  # lint-amnesty,
         # Since this is testing back to previous version, user should be set to true
         self.user.is_active = True
         self.user.save()
+
+    def test_post_invalid_site_token(self):
+        """This tests when the token belongs to an application with allowed uris different from the current url."""
+        dot_oauth2_client = self.dot_adapter.create_public_client(
+            name='client-example',
+            user=self.user,
+            client_id='client-dot-client-id',
+            redirect_uri='https://client.com/',
+        )
+        token = dot_models.AccessToken.objects.create(
+            user=self.user,
+            token='client-dot-access-token',
+            application=dot_oauth2_client,
+            expires=now() + timedelta(days=30),
+        )
+
+        response = self.post_with_bearer_token(self.OAUTH2_BASE_TESTING_URL, token=token)
+
+        self.check_error_codes(
+            response,
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            error_code=authentication.OAUTH2_TOKEN_ERROR_NONEXISTENT
+        )
 
 
 class OAuthDenyDisabledUsers(OAuth2AllowInActiveUsersTests):  # pylint: disable=test-inherits-tests


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR make changes from [Limonero migration](https://github.com/eduNEXT/edunext-platform/commit/9f2c793065) where restrict access token by application, with this allow to use the bearer token only in the tenant site for the application created and it can't be used in another tenant site.

## Supporting information

* [Limonero commit](https://github.com/eduNEXT/edunext-platform/commit/9f2c793065)

## Testing instructions

1. Use the changes with this branch ``nu/ednx/li-7``
2. Create two tenant sites (http://{lms_base}/admin/eox_tenant/tenantorganization/), for example tenant-a and tenant-b.
3. Create an application (http://{lms_base}/admin/oauth2_provider/application/), use:
* User: admin
* Redirect uris: add the tenan-a created in step 2
* Client type: confidential
* Authorization grant type: client credentials
4. Use postman to make a POST (http://{lms_base_tenant-a}/oauth2/access_token) to get an access token, use the ``client_id`` and ``client_secret`` created in step 3.
5. To test the funcionality, make a GET (http://{lms_base_tenat-a}/eox-tagging/api/v1/tags/), use the access token created in step 4. You have to get something like this:
```json
{
   "count": 0,
   "next": null,
   "previos": null,
   "results": []
}
```
6. Make a GET in other tenant site (http://{lms_base_tenat-b}/eox-tagging/api/v1/tags/), you can't access with the token for tenant-a, so you get something like this:
```json
{
   "error_code": "token_nonexistent",
   "developer_message": "The provider access token does not match any valid tokens."
}
```

## Deadline

"None" 

## Other information
- Test cases file: https://docs.google.com/document/d/11mpYNDDLeLgXheiafrL-7aCbvdzooeVGhWF78_NesPU/edit?usp=sharing
