### PR TITLE
feat: Add course type field to advanced settings and course info index

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -589,6 +589,7 @@ class CourseAboutSearchIndexer(CoursewareSearchIndexer):
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("course_type", AboutInfo.ANALYSE | AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1021,6 +1021,15 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         scope=Scope.settings
     )
 
+    course_type = String(
+        display_name=_("Course Type"),
+        help=_(
+            "Content type that helps the student to filter courses which are more interesting for them."
+        ),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseBlock(
     CourseFields,


### PR DESCRIPTION
## Description

This adds a new field in course advanced settings, requirement related to https://edunext.atlassian.net/browse/NELP-256

## Testing instructions

1. Just go to the advanced settings section in a course 

![image](https://user-images.githubusercontent.com/36200299/206752543-7e27dcb2-f95d-4226-adc6-b4af5088ab32.png)

