### PR TITLE
feat: update to nutmeg latest

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run-tests:
-    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-plastform' && (startsWith(github.base_ref, 'open-release') == false))
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     strategy:
       matrix:

--- a/.github/workflows/verify-gha-unit-tests-count.yml
+++ b/.github/workflows/verify-gha-unit-tests-count.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   collect-and-verify:
-    if: github.repository == 'openedx/edx-platform' || github.repository == 'edx/edx-platform-private'
+    if: (github.repository == 'edx/edx-platform-private') || (github.repository == 'openedx/edx-platform' && (startsWith(github.base_ref, 'open-release') == false))
     runs-on: [ edx-platform-runner ]
     steps:
       - name: sync directory owner

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -504,6 +504,11 @@ def component_handler(request, usage_key_string, handler, suffix=''):
     """
     usage_key = UsageKey.from_string(usage_key_string)
 
+    # Addendum:
+    # TNL 101-62 studio write permission is also checked for editing content.
+
+    if handler == 'submit_studio_edits' and not has_course_author_access(request.user, usage_key.course_key):
+        raise PermissionDenied("No studio write Permissions")
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, PropertyMock, patch
 
 import ddt
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -2196,6 +2197,15 @@ class TestComponentHandler(TestCase):
 
         self.assertEqual(component_handler(self.request, self.usage_key_string, 'dummy_handler').status_code,
                          status_code)
+
+    def test_submit_studio_edits_checks_author_permission(self):
+        with self.assertRaises(PermissionDenied):
+            with patch(
+                'common.djangoapps.student.auth.has_course_author_access',
+                return_value=False
+            ) as mocked_has_course_author_access:
+                component_handler(self.request, self.usage_key_string, 'submit_studio_edits')
+                assert mocked_has_course_author_access.called is True
 
     @ddt.data((True, True), (False, False),)
     @ddt.unpack

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -24,6 +24,7 @@ from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.statuses import ProctoredExamStudentAttemptStatus
 from edx_proctoring.tests.test_services import MockLearningSequencesService, MockScheduleItemData
 from edx_proctoring.tests.utils import ProctoredExamTestCase
+from oauth2_provider.models import AccessToken, RefreshToken
 from opaque_keys.edx.locator import BlockUsageLocator
 from organizations.tests.factories import OrganizationFactory
 from pytz import UTC
@@ -54,6 +55,7 @@ from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SSOVerificationFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.oauth_dispatch.tests import factories
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.enterprise_support.api import enterprise_is_enabled
@@ -151,6 +153,15 @@ class SupportViewManageUserTests(SupportViewTestCase):
         test_user = UserFactory(
             username='foobar', email='foobar@foobar.com', password='foobar'
         )
+
+        application = factories.ApplicationFactory(user=test_user)
+        access_token = factories.AccessTokenFactory(user=test_user, application=application)
+        factories.RefreshTokenFactory(
+            user=test_user, application=application, access_token=access_token
+        )
+        assert 0 != AccessToken.objects.filter(user=test_user).count()
+        assert 0 != RefreshToken.objects.filter(user=test_user).count()
+
         url = reverse('support:manage_user_detail') + test_user.username
         response = self.client.post(url, data={
             'username_or_email': test_user.username,
@@ -160,6 +171,8 @@ class SupportViewManageUserTests(SupportViewTestCase):
         assert data['success_msg'] == 'User Disabled Successfully'
         test_user = User.objects.get(username=test_user.username, email=test_user.email)
         assert test_user.has_usable_password() is False
+        assert 0 == AccessToken.objects.filter(user=test_user).count()
+        assert 0 == RefreshToken.objects.filter(user=test_user).count()
 
 
 @ddt.ddt

--- a/lms/djangoapps/support/views/manage_user.py
+++ b/lms/djangoapps/support/views/manage_user.py
@@ -75,7 +75,7 @@ class ManageUserDetailView(GenericAPIView):
             UserPasswordToggleHistory.objects.create(
                 user=user, comment=comment, created_by=request.user, disabled=True
             )
-            retire_dot_oauth2_models(request.user)
+            retire_dot_oauth2_models(user)
         else:
             user.set_password(generate_password(length=25))
             UserPasswordToggleHistory.objects.create(

--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -19,6 +19,13 @@ from openedx.core.djangoapps.password_policy.hibp import PwnedPasswordsAPI
 from openedx.core.djangoapps.user_api.accounts import USERNAME_MAX_LENGTH
 
 
+def _remove_unsafe_bytes_from_url(url):
+    _UNSAFE_URL_BYTES_TO_REMOVE = ["\t", "\r", "\n"]
+    for byte in _UNSAFE_URL_BYTES_TO_REMOVE:
+        url = url.replace(byte, "")
+    return url
+
+
 def is_safe_login_or_logout_redirect(redirect_to, request_host, dot_client_id, require_https):
     """
     Determine if the given redirect URL/path is safe for redirection.
@@ -41,6 +48,8 @@ def is_safe_login_or_logout_redirect(redirect_to, request_host, dot_client_id, r
     login_redirect_whitelist = set(getattr(settings, 'LOGIN_REDIRECT_WHITELIST', []))
     login_redirect_whitelist.add(request_host)
 
+    redirect_to = _remove_unsafe_bytes_from_url(redirect_to)
+
     # Allow OAuth2 clients to redirect back to their site after logout.
     if dot_client_id:
         application = Application.objects.get(client_id=dot_client_id)
@@ -50,6 +59,7 @@ def is_safe_login_or_logout_redirect(redirect_to, request_host, dot_client_id, r
     is_safe_url = http.is_safe_url(
         redirect_to, allowed_hosts=login_redirect_whitelist, require_https=require_https
     )
+
     return is_safe_url
 
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -88,6 +88,8 @@ class LogoutTests(TestCase):
 
     @ddt.data(
         ('https://www.amazon.org', 'edx.org'),
+        ('/%09/google.com/', 'edx.org'),
+        ('java%0D%0Ascript%0D%0A%3aalert(document.domain)', 'edx.org'),
     )
     @ddt.unpack
     def test_logout_redirect_failure(self, redirect_url, host):

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -168,3 +168,4 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
+xblock-drag-and-drop-v2             # Drag and Drop XBlock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1119,8 +1119,8 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/github.in
+xblock-drag-and-drop-v2==3.0.0
+    # via -r requirements/edx/base.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in
 xblock-utils==3.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1616,7 +1616,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -71,7 +71,6 @@ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc32118
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
 
 # Temporary for testing edx-django-utils upgrade
 git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-2054-move-cookie-monitoring-middleware#egg=edx_django_utils

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1489,7 +1489,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds all the commits needed to have an updated version based on open-release/nutmeg.master

## Changes

Commits added from commits in [nutmeg.master branch.](https://github.com/eduNEXT/edunext-platform/commits/ednx-release/nuez.master)

- [build: run tests for open-release branches on GH hosted runners](https://github.com/openedx/edx-platform/commit/cc801e1da7624deeb6981a91e964fadc01bd911c)
- [fix: xss and open redirect vul](https://github.com/openedx/edx-platform/commit/25608d6822ccd77c485b249c0a0e03894d8a6b5e)
- [fix: studio submit handler (nutmeg backport) (](https://github.com/openedx/edx-platform/commit/2b31b5b21c1603395644eea9c68d060baad2cf8e)https://github.com/openedx/edx-platform/pull/31221[)](https://github.com/openedx/edx-platform/commit/2b31b5b21c1603395644eea9c68d060baad2cf8e) 
- [feat!: update Drag and Drop v2 XBlock to prevent XSS vulnerabilities](https://github.com/openedx/edx-platform/commit/527b4993ae19258826600a5805c87cc2ace7040a)
- [fix: Fix retiring user auth models on disable event](https://github.com/openedx/edx-platform/commit/b67bfaa64d20ccb96aad77a571afd30abdda4a81)