### PR TITLE
feat: adding persistent grade event with test (#30916) (DS-335)

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1547,7 +1547,8 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
             user, mock_request,  # user is the person making the request.
             {
                 "user_id": str(thread_author.id),
-                "closed": False, "commentable_id": commentable_id,
+                "closed": False,
+                "commentable_id": commentable_id,
                 "context": "standalone",
                 "username": thread_author.username,
                 "course_id": str(self.course.id)

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -16,6 +16,8 @@ from hashlib import sha1
 
 from django.apps import apps
 from django.db import models, IntegrityError, transaction
+from openedx_events.learning.data import CourseData, PersistentCourseGradeData
+from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
 
 from django.utils.timezone import now
 from lazy import lazy
@@ -30,7 +32,6 @@ from openedx.core.lib.cache_utils import get_cache
 from lms.djangoapps.grades.signals.signals import COURSE_GRADE_PASSED_FIRST_TIME
 
 log = logging.getLogger(__name__)
-
 
 BLOCK_RECORD_LIST_VERSION = 1
 
@@ -655,6 +656,7 @@ class PersistentCourseGrade(TimeStampedModel):
 
         cls._emit_grade_calculated_event(grade)
         cls._update_cache(course_id, user_id, grade)
+        cls._emit_openedx_persistent_grade_summary_changed_event(course_id, user_id, grade)
         return grade
 
     @classmethod
@@ -670,6 +672,27 @@ class PersistentCourseGrade(TimeStampedModel):
     @staticmethod
     def _emit_grade_calculated_event(grade):
         events.course_grade_calculated(grade)
+
+    @staticmethod
+    def _emit_openedx_persistent_grade_summary_changed_event(course_id, user_id, grade):
+        """
+        When called emits an event when a persistent grade is created or updated.
+        """
+        # .. event_implemented_name: PERSISTENT_GRADE_SUMMARY_CHANGED
+        PERSISTENT_GRADE_SUMMARY_CHANGED.send_event(
+            grade=PersistentCourseGradeData(
+                user_id=user_id,
+                course=CourseData(
+                    course_key=course_id,
+                ),
+                course_edited_timestamp=grade.course_edited_timestamp,
+                course_version=grade.course_version,
+                grading_policy_hash=grade.grading_policy_hash,
+                percent_grade=grade.percent_grade,
+                letter_grade=grade.letter_grade,
+                passed_timestamp=grade.passed_timestamp,
+            )
+        )
 
 
 class PersistentSubsectionGradeOverride(models.Model):

--- a/lms/djangoapps/grades/tests/test_events.py
+++ b/lms/djangoapps/grades/tests/test_events.py
@@ -1,0 +1,95 @@
+"""
+Test that various events are fired for models in the grades app.
+"""
+
+from unittest import mock
+
+from django.utils.timezone import now
+from openedx_events.learning.data import CourseData, PersistentCourseGradeData
+from openedx_events.learning.signals import PERSISTENT_GRADE_SUMMARY_CHANGED
+from openedx_events.tests.utils import OpenEdxEventsTestMixin
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from common.djangoapps.student.tests.factories import UserFactory
+from lms.djangoapps.grades.models import PersistentCourseGrade
+
+
+class PersistentGradeEventsTest(SharedModuleStoreTestCase, OpenEdxEventsTestMixin):
+    """
+    Tests for the Open edX Events associated with the persistant grade process through the update_or_create method.
+
+    This class guarantees that the following events are sent during the user updates their grade, with
+    the exact Data Attributes as the event definition stated:
+
+        - PERSISTENT_GRADE_SUMMARY_CHANGED: sent after the user updates or creates the grade.
+    """
+    ENABLED_OPENEDX_EVENTS = [
+        "org.openedx.learning.course.persistent_grade_summary.changed.v1",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up class method for the Test class.
+
+        This method starts manually events isolation. Explanation here:
+        openedx/core/djangoapps/user_authn/views/tests/test_events.py#L44
+        """
+        super().setUpClass()
+        cls.start_events_isolation()
+
+    def setUp(self):  # pylint: disable=arguments-differ
+        super().setUp()
+        self.course = CourseFactory.create()
+        self.user = UserFactory.create()
+        self.params = {
+            "user_id": self.user.id,
+            "course_id": self.course.id,
+            "course_version": self.course.number,
+            "course_edited_timestamp": now(),
+            "percent_grade": 77.7,
+            "letter_grade": "Great job",
+            "passed": True,
+        }
+        self.receiver_called = False
+
+    def _event_receiver_side_effect(self, **kwargs):  # pylint: disable=unused-argument
+        """
+        Used show that the Open edX Event was called by the Django signal handler.
+        """
+        self.receiver_called = True
+
+    def test_persistent_grade_event_emitted(self):
+        """
+        Test whether the persistent grade updated event is sent after the user updates creates or updates their grade.
+
+        Expected result:
+            - PERSISTENT_GRADE_SUMMARY_CHANGED is sent and received by the mocked receiver.
+            - The arguments that the receiver gets are the arguments sent by the event
+            except the metadata generated on the fly.
+        """
+        event_receiver = mock.Mock(side_effect=self._event_receiver_side_effect)
+
+        PERSISTENT_GRADE_SUMMARY_CHANGED.connect(event_receiver)
+        grade = PersistentCourseGrade.update_or_create(**self.params)
+        self.assertTrue(self.receiver_called)
+        self.assertDictContainsSubset(
+            {
+                "signal": PERSISTENT_GRADE_SUMMARY_CHANGED,
+                "sender": None,
+                "grade": PersistentCourseGradeData(
+                    user_id=self.params["user_id"],
+                    course=CourseData(
+                        course_key=self.params["course_id"],
+                    ),
+                    course_edited_timestamp=self.params["course_edited_timestamp"],
+                    course_version=self.params["course_version"],
+                    grading_policy_hash='',
+                    percent_grade=self.params["percent_grade"],
+                    letter_grade=self.params["letter_grade"],
+                    passed_timestamp=grade.passed_timestamp
+                )
+            },
+            event_receiver.call_args.kwargs
+        )

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -24,7 +24,13 @@ Django<4.0
 # elastic search changelog: https://www.elastic.co/guide/en/enterprise-search/master/release-notes-7.14.0.html
 elasticsearch<7.14.0
 
+# setuptools==60.0 had breaking changes and busted several service's pipeline.
+# Details can be found here: https://github.com/pypa/setuptools/issues/2940
 setuptools<60
 
 # django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
 django-simple-history==3.0.0
+
+# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
+# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
+tox<4.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -736,7 +736,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-events==0.8.1
+openedx-events==0.13.0
     # via -r requirements/edx/base.in
 openedx-filters==0.7.0
     # via -r requirements/edx/base.in
@@ -822,6 +822,7 @@ pylti1p3==1.10.0
     # via -r requirements/edx/base.in
 pymongo==3.12.3
     # via
+    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
     #   edx-opaque-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -978,7 +978,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==0.8.1
+openedx-events==0.13.0
     # via -r requirements/edx/testing.txt
 openedx-filters==0.7.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -923,7 +923,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-events==0.8.1
+openedx-events==0.13.0
     # via -r requirements/edx/base.txt
 openedx-filters==0.7.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
This PR incorporates the Persistent Grade Event feature into Nuez. It was done by a backport from this [PR](https://github.com/openedx/edx-platform/pull/30916). If you're intrested in trying it: 
1. Use the [openedx-events-2-zapier](https://github.com/eduNEXT/openedx-events-2-zapier) repository, [here](https://docs.tutor.overhang.io/dev.html#xblock-and-edx-platform-plugin-development) are instructions on how to install it. 
2. Create a simple tutor plugin as follows:
```
name: event-to-webhook
version: 0.1.0
patches:
 lms-env: |
  "ZAPIER_PERSISTENT_GRADE_COURSE_WEBHOOK": "url-zapier-or-webhook"
```
3. Use your zappier account or you can use [webhook](https://webhook.site/) in case you don't have one.