### PR TITLE
fix: Typo in get custom context

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1295,11 +1295,14 @@ def _certificate_message(student, course, enrollment_mode):  # lint-amnesty, pyl
     if cert_downloadable_status['is_generating']:
         return GENERATING_CERT_DATA
 
-    if cert_downloadable_status['is_unverified'] or _missing_required_verification(student, enrollment_mode):
+    if cert_downloadable_status['is_unverified']:
         return _unverified_cert_data()
 
     if cert_downloadable_status['is_downloadable']:
         return _downloadable_certificate_message(course, cert_downloadable_status)
+
+    if _missing_required_verification(student, enrollment_mode):
+        return _unverified_cert_data()
 
     return REQUESTING_CERT_DATA
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1295,14 +1295,11 @@ def _certificate_message(student, course, enrollment_mode):  # lint-amnesty, pyl
     if cert_downloadable_status['is_generating']:
         return GENERATING_CERT_DATA
 
-    if cert_downloadable_status['is_unverified']:
+    if cert_downloadable_status['is_unverified'] or _missing_required_verification(student, enrollment_mode):
         return _unverified_cert_data()
 
     if cert_downloadable_status['is_downloadable']:
         return _downloadable_certificate_message(course, cert_downloadable_status)
-
-    if _missing_required_verification(student, enrollment_mode):
-        return _unverified_cert_data()
 
     return REQUESTING_CERT_DATA
 

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -111,7 +111,7 @@ class AddCustomOptionsOnAccountSettings(PipelineStep):
             if options:
                 field_options[field_name] = options
 
-            return field_options, field_labels
+        return field_options, field_labels
 
 
 class AccountSettingsRenderStarted(OpenEdxPublicFilter):


### PR DESCRIPTION
## Description

This PR is to fix an issue with https://github.com/eduNEXT/edunext-platform/pull/691

## Testing instructions

You can follow same instructions that JU-11, but you can try without any custom fields activated too. 

Without this fix you get this error:

![image](https://user-images.githubusercontent.com/39854568/209580257-7e95f69c-d90d-4044-8163-82054e75fc4b.png)

With this fix you can have this filter working without custom fields defined.