### PR TITLE
fix: tab typo in get custom context

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -111,7 +111,7 @@ class AddCustomOptionsOnAccountSettings(PipelineStep):
             if options:
                 field_options[field_name] = options
 
-            return field_options, field_labels
+        return field_options, field_labels
 
 
 class AccountSettingsRenderStarted(OpenEdxPublicFilter):


### PR DESCRIPTION
## Description
This PR is to fix an issue with https://github.com/eduNEXT/edunext-platform/pull/691

## Testing instructions
You can follow same instructions that JU-11, but you can try without any custom fields activated too.

Without this fix you get this error:

![image](https://user-images.githubusercontent.com/39854568/209580644-82f45019-286d-4bd4-9854-ae4dbce116b3.png)

With this fix you can have this filter working without custom fields defined.