### PR TITLE
perf: change queryset to get_queryset in CourseEnrollmentAdmin DS-350

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -305,8 +305,8 @@ class CourseEnrollmentAdmin(DisableEnrollmentAdminMixin, admin.ModelAdmin):
 
         return qs, use_distinct
 
-    def queryset(self, request):
-        return super().queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related('user')  # lint-amnesty, pylint: disable=no-member, super-with-arguments
 
 
 class UserProfileInline(admin.StackedInline):


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This is a backport of https://github.com/openedx/edx-platform/pull/31520 to have a course enrollment admin less slow.

## Note
With Service Delivery, we are testing this in stage to know if this change is enough improvement for the course enrollment admin in saas for solving the associate Jira card.
