### PR TITLE
Jlc/mfe learning by tenant settings

### DIFF
--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -4,6 +4,7 @@ Toggles for course home experience.
 
 from edx_toggles.toggles import LegacyWaffleFlagNamespace
 
+from lms.lib.utils import use_learning_legacy_frontend
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_home')
@@ -26,7 +27,10 @@ COURSE_HOME_USE_LEGACY_FRONTEND = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'cours
 
 
 def course_home_legacy_is_active(course_key):
-    return COURSE_HOME_USE_LEGACY_FRONTEND.is_enabled(course_key) or course_key.deprecated
+    return (
+        use_learning_legacy_frontend() and
+        (COURSE_HOME_USE_LEGACY_FRONTEND.is_enabled(course_key) or course_key.deprecated)
+    )
 
 
 def course_home_mfe_progress_tab_is_active(course_key):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -5,6 +5,7 @@ Toggles for courseware in-course experience.
 from edx_toggles.toggles import LegacyWaffleFlagNamespace, SettingToggle
 from opaque_keys.edx.keys import CourseKey
 
+from lms.lib.utils import use_learning_legacy_frontend
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
@@ -127,7 +128,7 @@ def courseware_mfe_is_active(course_key: CourseKey) -> bool:
         return False
     # NO: MFE courseware can be disabled for users/courses/globally via this
     #     Waffle flag.
-    if COURSEWARE_USE_LEGACY_FRONTEND.is_enabled(course_key):
+    if use_learning_legacy_frontend() and COURSEWARE_USE_LEGACY_FRONTEND.is_enabled(course_key):
         return False
     # NO: Course preview doesn't work in the MFE
     if in_preview_mode():

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -2,6 +2,8 @@
 Helper methods for the LMS.
 """
 
+from django.conf import settings
+
 
 def get_parent_unit(xblock):
     """
@@ -44,3 +46,15 @@ def is_unit(xblock):
     """
 
     return get_parent_unit(xblock) is None and xblock.get_parent()
+
+
+def use_learning_legacy_frontend() -> bool:
+    """
+    Checks in django settings if use the learning legacy
+    frontend instead the learning mfe.
+
+    Returns:
+        True if the legacy frontend setting is activated, by default
+        legacy would be activated.
+    """
+    return bool(getattr(settings, "USE_LEARNING_LEGACY_FRONTEND", True))


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
Add the possibility to manage the learning MFE by the tenant using `USE_LEARNING_LEGACY_FRONTEND`.

**Useful information to include:**
- The main Django switches for the legacy frontend have to be turned on.
![2023-01-30_14-50](https://user-images.githubusercontent.com/51926076/215581177-8dea6d51-e524-45cf-906c-2cedb0bbc2ae.png)
-  By default, the tenant would use legacy learning instead MFE.
- To use MFE you have to set the tenant config var `USE_LEARNING_LEGACY_FRONTEND: false`
- To load the change you have to load a different tenant each time this setting is configured.


## Usage
- changes refreshing using  `USE_LEARNING_LEGACY_FRONTEND`
![Peek 2023-01-30 14-44](https://user-images.githubusercontent.com/51926076/215581627-393fb24a-8e84-4dc5-9c58-b3223eaa2d15.gif)

- changes without the `USE_LEARNING_LEGACY_FRONTEND` defined.
![Peek 2023-01-30 14-52](https://user-images.githubusercontent.com/51926076/215581646-4ae230d3-84eb-4afa-a311-99b9f7c72e80.gif)
- [x] tested in stage with https://lms.stage.nelp.gov.sa/ and  https://edunext.stage.nelp.gov.sa/ 