### PR TITLE
Jlc/backport upgrade pymongo version

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -223,6 +223,17 @@ add_plugins(__name__, ProjectType.CMS, SettingsType.DEVSTACK)
 OPENAPI_CACHE_TIMEOUT = 0
 
 #####################################################################
+# set replica set of contentstore to none as we haven't setup any for cms in devstack
+CONTENTSTORE['DOC_STORE_CONFIG']['replicaSet'] = None
+
+#####################################################################
+# set replica sets of moduelstore to none as we haven't setup any for cms in devstack
+for store in MODULESTORE['default']['OPTIONS']['stores']:
+    if 'DOC_STORE_CONFIG' in store and 'replicaSet' in store['DOC_STORE_CONFIG']:
+        store['DOC_STORE_CONFIG']['replicaSet'] = None
+
+
+#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -162,7 +162,7 @@ ENTERPRISE_CONSENT_API_URL = ENV_TOKENS.get('ENTERPRISE_CONSENT_API_URL', LMS_IN
 # Studio. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
 IDA_LOGOUT_URI_LIST = ENV_TOKENS.get('IDA_LOGOUT_URI_LIST', [])
 
-SITE_NAME = ENV_TOKENS['SITE_NAME']
+SITE_NAME = ENV_TOKENS.get('SITE_NAME', SITE_NAME)
 
 ALLOWED_HOSTS = [
     # TODO: bbeggs remove this before prod, temp fix to get load testing running
@@ -170,10 +170,10 @@ ALLOWED_HOSTS = [
     CMS_BASE,
 ]
 
-LOG_DIR = ENV_TOKENS['LOG_DIR']
+LOG_DIR = ENV_TOKENS.get('LOG_DIR', LOG_DIR)
 DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
-CACHES = ENV_TOKENS['CACHES']
+CACHES = ENV_TOKENS.get('CACHES', CACHES)
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.
 if 'loc_cache' not in CACHES:
@@ -260,7 +260,7 @@ for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
     INSTALLED_APPS.append(app)
 
 LOGGING = get_logger_config(LOG_DIR,
-                            logging_env=ENV_TOKENS['LOGGING_ENV'],
+                            logging_env=ENV_TOKENS.get('LOGGING_ENV', LOGGING_ENV),
                             service_variant=SERVICE_VARIANT)
 
 # The following variables use (or) instead of the default value inside (get). This is to enforce using the Lazy Text
@@ -301,11 +301,11 @@ CMS_SEGMENT_KEY = AUTH_TOKENS.get('SEGMENT_KEY')
 
 SECRET_KEY = AUTH_TOKENS['SECRET_KEY']
 
-AWS_ACCESS_KEY_ID = AUTH_TOKENS["AWS_ACCESS_KEY_ID"]
+AWS_ACCESS_KEY_ID = AUTH_TOKENS.get("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
 if AWS_ACCESS_KEY_ID == "":
     AWS_ACCESS_KEY_ID = None
 
-AWS_SECRET_ACCESS_KEY = AUTH_TOKENS["AWS_SECRET_ACCESS_KEY"]
+AWS_SECRET_ACCESS_KEY = AUTH_TOKENS.get("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
 if AWS_SECRET_ACCESS_KEY == "":
     AWS_SECRET_ACCESS_KEY = None
 
@@ -343,7 +343,7 @@ if COURSE_METADATA_EXPORT_BUCKET:
 else:
     COURSE_METADATA_EXPORT_STORAGE = DEFAULT_FILE_STORAGE
 
-DATABASES = AUTH_TOKENS['DATABASES']
+DATABASES = AUTH_TOKENS.get('DATABASES', DATABASES)
 
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*
@@ -371,8 +371,8 @@ XBLOCK_FIELD_DATA_WRAPPERS = ENV_TOKENS.get(
     XBLOCK_FIELD_DATA_WRAPPERS
 )
 
-CONTENTSTORE = AUTH_TOKENS['CONTENTSTORE']
-DOC_STORE_CONFIG = AUTH_TOKENS['DOC_STORE_CONFIG']
+CONTENTSTORE = AUTH_TOKENS.get('CONTENTSTORE', CONTENTSTORE)
+DOC_STORE_CONFIG = AUTH_TOKENS.get('DOC_STORE_CONFIG', DOC_STORE_CONFIG)
 
 ############################### BLOCKSTORE #####################################
 BLOCKSTORE_API_URL = ENV_TOKENS.get('BLOCKSTORE_API_URL', None)  # e.g. "https://blockstore.example.com/api/v1/"

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -324,8 +324,20 @@ REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
 OPENAPI_CACHE_TIMEOUT = 0
 
 #####################################################################
+# set replica set of contentstore to none as we haven't setup any for lms in devstack
+CONTENTSTORE['DOC_STORE_CONFIG']['replicaSet'] = None
+
+#####################################################################
+# set replica sets of moduelstore to none as we haven't setup any for lms in devstack
+for store in MODULESTORE['default']['OPTIONS']['stores']:
+    if 'DOC_STORE_CONFIG' in store and 'replicaSet' in store['DOC_STORE_CONFIG']:
+        store['DOC_STORE_CONFIG']['replicaSet'] = None
+
+
+#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
+
 
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -151,7 +151,7 @@ EMAIL_FILE_PATH = ENV_TOKENS.get('EMAIL_FILE_PATH', None)
 EMAIL_HOST = ENV_TOKENS.get('EMAIL_HOST', 'localhost')  # django default is localhost
 EMAIL_PORT = ENV_TOKENS.get('EMAIL_PORT', 25)  # django default is 25
 EMAIL_USE_TLS = ENV_TOKENS.get('EMAIL_USE_TLS', False)  # django default is False
-SITE_NAME = ENV_TOKENS['SITE_NAME']
+SITE_NAME = ENV_TOKENS.get('SITE_NAME', SITE_NAME)
 SESSION_COOKIE_DOMAIN = ENV_TOKENS.get('SESSION_COOKIE_DOMAIN')
 SESSION_COOKIE_HTTPONLY = ENV_TOKENS.get('SESSION_COOKIE_HTTPONLY', True)
 
@@ -207,7 +207,7 @@ if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
 # By default, it's set to the same thing as the SESSION_COOKIE_DOMAIN, but we want to make it overrideable.
 SHARED_COOKIE_DOMAIN = ENV_TOKENS.get('SHARED_COOKIE_DOMAIN', SESSION_COOKIE_DOMAIN)
 
-CACHES = ENV_TOKENS['CACHES']
+CACHES = ENV_TOKENS.get('CACHES', CACHES)
 # Cache used for location mapping -- called many times with the same key/value
 # in a given request.
 if 'loc_cache' not in CACHES:
@@ -309,11 +309,11 @@ for app in ENV_TOKENS.get('ADDL_INSTALLED_APPS', []):
 
 
 local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
-LOG_DIR = ENV_TOKENS['LOG_DIR']
+LOG_DIR = ENV_TOKENS.get('LOG_DIR', LOG_DIR)
 DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
 LOGGING = get_logger_config(LOG_DIR,
-                            logging_env=ENV_TOKENS['LOGGING_ENV'],
+                            logging_env=ENV_TOKENS.get('LOGGING_ENV', LOGGING_ENV),
                             local_loglevel=local_loglevel,
                             service_variant=SERVICE_VARIANT)
 
@@ -438,11 +438,11 @@ LMS_SEGMENT_KEY = AUTH_TOKENS.get('SEGMENT_KEY')
 
 SECRET_KEY = AUTH_TOKENS['SECRET_KEY']
 
-AWS_ACCESS_KEY_ID = AUTH_TOKENS["AWS_ACCESS_KEY_ID"]
+AWS_ACCESS_KEY_ID = AUTH_TOKENS.get("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID)
 if AWS_ACCESS_KEY_ID == "":
     AWS_ACCESS_KEY_ID = None
 
-AWS_SECRET_ACCESS_KEY = AUTH_TOKENS["AWS_SECRET_ACCESS_KEY"]
+AWS_SECRET_ACCESS_KEY = AUTH_TOKENS.get("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY)
 if AWS_SECRET_ACCESS_KEY == "":
     AWS_SECRET_ACCESS_KEY = None
 
@@ -462,7 +462,7 @@ else:
 
 # If there is a database called 'read_replica', you can use the use_read_replica_if_available
 # function in util/query.py, which is useful for very large database reads
-DATABASES = AUTH_TOKENS['DATABASES']
+DATABASES = AUTH_TOKENS.get('DATABASES', DATABASES)
 
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*
@@ -478,7 +478,7 @@ for name, database in DATABASES.items():
             'PORT': os.environ.get('DB_MIGRATION_PORT', database['PORT']),
         })
 
-XQUEUE_INTERFACE = AUTH_TOKENS['XQUEUE_INTERFACE']
+XQUEUE_INTERFACE = AUTH_TOKENS.get('XQUEUE_INTERFACE', XQUEUE_INTERFACE)
 
 # Get the MODULESTORE from auth.json, but if it doesn't exist,
 # use the one from common.py

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -57,8 +57,9 @@ networkx<2.6
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
 
-# tests failing for pymongo==3.11
-pymongo<3.11
+# constrained in opaque_keys. migration guide here: https://pymongo.readthedocs.io/en/4.0/migrate-to-pymongo4.html
+# Major upgrade will be done in separate ticket.
+pymongo<4.0.0
 
 # sympy latest version causing test failures.
 # may be related to python35 version drop in 1.7.0. Needs to be tested before removing.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -764,9 +764,8 @@ pylatexenc==2.10
     # via olxcleaner
 pylti1p3==1.9.1
     # via -r requirements/edx/base.in
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   -r requirements/edx/paver.txt
     #   edx-opaque-keys

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1068,9 +1068,8 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.txt
 pylti1p3==1.9.1
     # via -r requirements/edx/testing.txt
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   edx-opaque-keys
     #   event-tracking

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -28,7 +28,7 @@ pbr==5.6.0
     # via stevedore
 psutil==5.8.0
     # via -r requirements/edx/paver.in
-pymongo==3.10.1
+pymongo==3.12.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/paver.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1000,9 +1000,8 @@ pylint-pytest==0.3.0
     # via -r requirements/edx/testing.in
 pylti1p3==1.9.1
     # via -r requirements/edx/base.txt
-pymongo==3.10.1
+pymongo==3.12.3
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   edx-opaque-keys
     #   event-tracking


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
This pr adds 2 commits backported from master. 
- First commit Upgrade pymongo to improve functionality with the mongo 4.4 version, which is the one used in our atlas instance
- The second commit is something to avoid errors in cms for local environments.

**extra_info**: already deployed in stage.

## Testing instructions
### Local test
Checkout this branch.
If you are using tutor remove from `lms.env.json `and `cms.env.json` this lines due devstack changes, and contentstore should not be `none` and load `common.py` values.
https://github.com/overhangio/tutor/blob/v13.3.0/tutor/templates/apps/openedx/config/partials/auth.json#L4-L5

![2023-03-31_16-00](https://user-images.githubusercontent.com/51926076/229244455-12f3b62d-245a-4003-b81b-ffd2a1bd0733.png)

Go to your lms local container and install requirements.

![2023-03-31_16-10](https://user-images.githubusercontent.com/51926076/229246449-c45cddb4-c9f9-4016-ada4-c13f6ad537c7.png)

Test creating a course and check if there is no problem. 
![2023-03-31_16-29](https://user-images.githubusercontent.com/51926076/229246497-1bd7aec0-f38c-479e-8cbd-ca10d0c39496.png)





