### PR TITLE
fix: adding TypeError to compare scores function

### DIFF
--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -152,7 +152,7 @@ def score_published_handler(sender, block, user, raw_earned, raw_possible, only_
         if previous_score is not None:
             prev_raw_earned, prev_raw_possible = (previous_score.grade, previous_score.max_grade)
 
-            if not is_score_higher_or_equal(prev_raw_earned, prev_raw_possible, raw_earned, raw_possible):
+            if not is_score_higher_or_equal(prev_raw_earned, prev_raw_possible, raw_earned, raw_possible, True):
                 update_score = False
                 log.warning(
                     "Grades: Rescore is not higher than previous: "

--- a/openedx/core/lib/grade_utils.py
+++ b/openedx/core/lib/grade_utils.py
@@ -17,14 +17,14 @@ def compare_scores(earned1, possible1, earned2, possible2, treat_undefined_as_ze
     """
     try:
         percentage1 = float(earned1) / float(possible1)
-    except ZeroDivisionError:
+    except (ZeroDivisionError, TypeError):
         if not treat_undefined_as_zero:
             raise
         percentage1 = 0.0
 
     try:
         percentage2 = float(earned2) / float(possible2)
-    except ZeroDivisionError:
+    except (ZeroDivisionError, TypeError):
         if not treat_undefined_as_zero:
             raise
         percentage2 = 0.0


### PR DESCRIPTION
This PR is intended to fix some problems that occur when we try to save the state of the h5pxblock.

These problems occur when we set the only_if_higher flag and the first time the x-block tries to retrieve the previous value and the previous maximum value, since these were saved as NULL when the x-block saved the interaction_data.