### PR TITLE
Revert "feat(LC-v2): select language"

### DIFF
--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -86,10 +86,9 @@ class DarkLangMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """
-        eduNEXT: this middleware will always process the requests.
-        The model has been modified to not even attempt the db lookup
+        Prevent user from requesting un-released languages except by using the preview-lang query string.
         """
-        if not settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False) and not DarkLangConfig.current().enabled:
+        if not DarkLangConfig.current().enabled:
             return
 
         self._clean_accept_headers(request)
@@ -138,13 +137,8 @@ class DarkLangMiddleware(MiddlewareMixin):
         Remove any language that is not either in ``self.released_langs`` or
         a territory of one of those languages.
         """
-        ednx_locale = settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False)
         accept = request.META.get('HTTP_ACCEPT_LANGUAGE', None)
         if accept is None or accept == '*':
-            if ednx_locale:
-                # eduNEXT: return the site aware settings.LANGUAGE_CODE
-                # so that django.utils.locale.LocaleMiddleware can pick it up
-                request.META['HTTP_ACCEPT_LANGUAGE'] = f"{settings.LANGUAGE_CODE};q=0.1"
             return
 
         new_accept = []
@@ -153,9 +147,6 @@ class DarkLangMiddleware(MiddlewareMixin):
             if fuzzy_code:
                 # Formats lang and priority into a valid accept header fragment.
                 new_accept.append(f"{fuzzy_code};q={priority}")
-            elif ednx_locale:
-                # eduNEXT: if there is no match, we set it to the settings.LANGUAGE_CODE
-                new_accept.append(f"{settings.LANGUAGE_CODE};q=0.1")
 
         new_accept = ", ".join(new_accept)
 

--- a/openedx/core/djangoapps/dark_lang/models.py
+++ b/openedx/core/djangoapps/dark_lang/models.py
@@ -4,7 +4,6 @@ Models for the dark-launching languages
 
 
 from config_models.models import ConfigurationModel
-from django.conf import settings
 from django.db import models
 
 
@@ -36,19 +35,13 @@ class DarkLangConfig(ConfigurationModel):
         ``released_languages`` as a list of language codes.
 
         Example: ['it', 'de-at', 'es', 'pt-br']
-
-        eduNEXT: we support only the list of available languages from the site
-        otherwise is the same as having no configuration
         """
-        released_languages = self.released_languages
+        if not self.released_languages.strip():
+            return []
 
-        if settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
-            released_languages = getattr(settings, "released_languages", "")
-
-        languages = [lang.lower().strip() for lang in released_languages.split(',')]
+        languages = [lang.lower().strip() for lang in self.released_languages.split(',')]
         # Put in alphabetical order
         languages.sort()
-
         return languages
 
     @property


### PR DESCRIPTION
## Description

This reverts commit 303f68f65dc9c8c8fdb89e30b21fec09fe6e1dd8.

This revert is being carried out because the following functionality is going to be deployed to production in nuez.saas: https://github.com/eduNEXT/eox-tenant/pull/184.

Service Delivery mounted an image with the changes made in stage, it can be seen at: 
https://learner-demo-edunext-co.ne.edunextstage.net/ 
https://internal-sd-edunext-co.ne.edunextstage.net/