### PR TITLE
Binary gender in Saudi Arabia

### DIFF
--- a/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
+++ b/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
@@ -228,7 +228,7 @@ class Migration(migrations.Migration):
                 ('language', models.CharField(blank=True, db_index=True, max_length=255)),
                 ('location', models.CharField(blank=True, db_index=True, max_length=255)),
                 ('year_of_birth', models.IntegerField(blank=True, db_index=True, null=True)),
-                ('gender', models.CharField(blank=True, choices=[('m', 'Male'), ('f', 'Female'), ('o', 'Other/Prefer Not to Say')], db_index=True, max_length=6, null=True)),
+                ('gender', models.CharField(blank=True, choices=[('m', 'Male'), ('f', 'Female')], db_index=True, max_length=6, null=True)),
                 ('level_of_education', models.CharField(blank=True, choices=[('p', 'Doctorate'), ('m', "Master's or professional degree"), ('b', "Bachelor's degree"), ('a', 'Associate degree'), ('hs', 'Secondary/high school'), ('jhs', 'Junior secondary/junior high/middle school'), ('el', 'Elementary/primary school'), ('none', 'No formal education'), ('other', 'Other education')], db_index=True, max_length=6, null=True)),
                 ('mailing_address', models.TextField(blank=True, null=True)),
                 ('city', models.TextField(blank=True, null=True)),

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -531,8 +531,6 @@ class UserProfile(models.Model):
     GENDER_CHOICES = (
         ('m', gettext_noop('Male')),
         ('f', gettext_noop('Female')),
-        # Translators: 'Other' refers to the student's gender
-        ('o', gettext_noop('Other/Prefer Not to Say'))
     )
     gender = models.CharField(
         blank=True, null=True, max_length=6, db_index=True, choices=GENDER_CHOICES

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -866,7 +866,6 @@ class RegistrationViewTestV1(
                     {"value": "", "name": "--", "default": True},
                     {"value": "m", "name": "Male", "default": False},
                     {"value": "f", "name": "Female", "default": False},
-                    {"value": "o", "name": "Other/Prefer Not to Say", "default": False},
                 ],
             }
         )
@@ -886,7 +885,6 @@ class RegistrationViewTestV1(
                     {"value": "", "name": "--", "default": True},
                     {"value": "m", "name": "Male TRANSLATED", "default": False},
                     {"value": "f", "name": "Female TRANSLATED", "default": False},
-                    {"value": "o", "name": "Other/Prefer Not to Say TRANSLATED", "default": False},
                 ],
             }
         )


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

According to Saudi Arabia's culture and laws, we cannot have a third option in the gender field `Other/Prefer Not to Say`. We're removing it from their branch

This change shouldn't have any effect on the platform's behavior

## Supporting information

Check Slack

## Testing instructions

None

## Deadline

very urgent

## Other information

None