### PR TITLE
feat: add feature to block publish course

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -121,7 +121,7 @@ class ModifyUsageKeyRequestStarted(OpenEdxPublicFilter):
     Custom class used to request plublish course filters.
     """
 
-    filter_type = "org.openedx.studio.contentstore.modify_usage_key_ request.started.v1"
+    filter_type = "org.openedx.studio.contentstore.modify_usage_key_request.started.v1"
 
     class PreventModifyUsageKeyRequest(OpenEdxFilterException):
         """

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -194,11 +194,15 @@ def xblock_handler(request, usage_key_string=None):
                      if duplicate_source_locator is not present
               The locator (unicode representation of a UsageKey) for the created xblock (minus children) is returned.
     """
-    usage_key = usage_key_with_run(usage_key_string)
-    usage_key = usage_key.course_key
+    filter_usage_key = usage_key_string
+    if not filter_usage_key:
+        filter_usage_key = request.json["parent_locator"]
+
+    course_key = usage_key_with_run(filter_usage_key)
+    course_key = course_key.course_key
 
     try:
-        request = ModifyUsageKeyRequestStarted().run_filter(request, usage_key)
+        request = ModifyUsageKeyRequestStarted().run_filter(request, course_key)
     except:
         raise PermissionDenied()
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -688,7 +688,7 @@ def _save_xblock(user, xblock, data=None, children_strings=None, metadata=None, 
 
         # Make public after updating the xblock, in case the caller asked for both an update and a publish.
         # Used by Bok Choy tests and by republishing of staff locks.
-        if publish == 'make_public':
+        if publish == 'make_public' and settings.PUBLISH_COURSE:
             modulestore().publish(xblock.location, user.id)
 
         # Note that children aren't being returned until we have a use case.

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -688,7 +688,7 @@ def _save_xblock(user, xblock, data=None, children_strings=None, metadata=None, 
 
         # Make public after updating the xblock, in case the caller asked for both an update and a publish.
         # Used by Bok Choy tests and by republishing of staff locks.
-        if publish == 'make_public' and settings.PUBLISH_COURSE:
+        if publish == 'make_public' and getattr(settings, 'PUBLISH_COURSE', False):
             modulestore().publish(xblock.location, user.id)
 
         # Note that children aren't being returned until we have a use case.

--- a/cms/djangoapps/maintenance/views.py
+++ b/cms/djangoapps/maintenance/views.py
@@ -17,7 +17,6 @@ from django.views.generic.list import ListView
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from openedx_filters import PipelineStep
 from openedx_filters.exceptions import OpenEdxFilterException
 from openedx_filters.tooling import OpenEdxPublicFilter
 from cms.djangoapps.contentstore.management.commands.utils import get_course_versions
@@ -100,7 +99,6 @@ class ForcePublishCourseRenderStarted(OpenEdxPublicFilter):
             """
             super().__init__(message, redirect_to=redirect_to)
 
-
     @classmethod
     def run_filter(cls, context, template_name):
         """
@@ -112,34 +110,6 @@ class ForcePublishCourseRenderStarted(OpenEdxPublicFilter):
         """
         data = super().run_pipeline(context=context, template_name=template_name)
         return data.get("context"), data.get("template_name")
-
-
-
-class StopForcePublishCourseRender(PipelineStep):
-    """
-    Stop account settings render process raising RedirectToPage exception.
-
-    Example usage:
-
-    Add the following configurations to your configuration file:
-
-        "OPEN_EDX_FILTERS_CONFIG": {
-            "org.openedx.studio.manages.force_publish.render.started.v1": {
-                "fail_silently": false,
-                "pipeline": [
-                    "cms.djangoapps.maintenance.views.StopForcePublishCourseRender"
-                ]
-            }
-        },
-    """
-    def run_filter(self, context, *args, **kwargs):  # pylint: disable=arguments-differ
-        """
-        Pipeline step that stop force publish course page.
-        """
-        raise ForcePublishCourseRenderStarted.RedirectToPage(
-            "You can't access to account settings.",
-            redirect_to="",
-        )
 
 
 class MaintenanceBaseView(View):

--- a/cms/djangoapps/maintenance/views.py
+++ b/cms/djangoapps/maintenance/views.py
@@ -144,7 +144,8 @@ class MaintenanceBaseView(View):
         else:
             if self.request.is_ajax():
                 response = JsonResponse(context)
-            response = render_to_response(template_name, context)
+            else:
+                response = render_to_response(template_name, context)
 
         return response
 


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR block the publish course button in Studio. The conditions are:

* To prevent Force Publish "admin>maintenance>Force Publish Course" we add a filter to render to other view and avoid publish function
* To prevent Publish "inside the container course" we add a filter to modify the request content to edit or publish the course. (New update: https://github.com/eduNEXT/edunext-platform/pull/776/files#diff-cb646e068cf811612f67002df90b4fa8071c7644824f6e52cb4efe143f96289b)

Useful information to include:
- Document with the implementation https://docs.google.com/document/d/1qpFE_smFm8vDWzqA2tZbtRkA-st-B5jl6oPcPS6u1CY/edit?usp=sharing


## Testing instructions

Continue the instructions on the document

## Other information

- Jira card: https://edunext.atlassian.net/jira/software/c/projects/DS/boards/40?selectedIssue=DS-621