### PR TITLE
feat: add mfe control setting

### DIFF
--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -4,6 +4,7 @@ Toggles for course home experience.
 
 from edx_toggles.toggles import LegacyWaffleFlagNamespace
 
+from lms.lib.utils import use_learning_legacy_frontend
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_home')
@@ -26,7 +27,10 @@ COURSE_HOME_USE_LEGACY_FRONTEND = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'cours
 
 
 def course_home_legacy_is_active(course_key):
-    return COURSE_HOME_USE_LEGACY_FRONTEND.is_enabled(course_key) or course_key.deprecated
+    return (
+        use_learning_legacy_frontend() and
+        (COURSE_HOME_USE_LEGACY_FRONTEND.is_enabled(course_key) or course_key.deprecated)
+    )
 
 
 def course_home_mfe_progress_tab_is_active(course_key):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -5,6 +5,7 @@ Toggles for courseware in-course experience.
 from edx_toggles.toggles import LegacyWaffleFlagNamespace, SettingToggle
 from opaque_keys.edx.keys import CourseKey
 
+from lms.lib.utils import use_learning_legacy_frontend
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
@@ -140,7 +141,7 @@ def courseware_mfe_is_active(course_key: CourseKey) -> bool:
         return False
     # NO: MFE courseware can be disabled for users/courses/globally via this
     #     Waffle flag.
-    if COURSEWARE_USE_LEGACY_FRONTEND.is_enabled(course_key):
+    if use_learning_legacy_frontend() and COURSEWARE_USE_LEGACY_FRONTEND.is_enabled(course_key):
         return False
     # NO: Course preview doesn't work in the MFE
     if in_preview_mode():

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -52,7 +52,7 @@ def use_learning_legacy_frontend() -> bool:
     """
     THIS WILL BE OBSOLETE FROM VERSIONS HIGHER THAN NUTMEG
     https://docs.openedx.org/en/latest/community/release_notes/olive.html#learning-mfe-is-now-required
-    
+
     Checks in django settings if use the learning legacy
     frontend instead the learning mfe.
 

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -50,6 +50,9 @@ def is_unit(xblock):
 
 def use_learning_legacy_frontend() -> bool:
     """
+    THIS WILL BE OBSOLETE FROM VERSIONS HIGHER THAN NUTMEG
+    https://docs.openedx.org/en/latest/community/release_notes/olive.html#learning-mfe-is-now-required
+    
     Checks in django settings if use the learning legacy
     frontend instead the learning mfe.
 

--- a/lms/lib/utils.py
+++ b/lms/lib/utils.py
@@ -2,6 +2,8 @@
 Helper methods for the LMS.
 """
 
+from django.conf import settings
+
 
 def get_parent_unit(xblock):
     """
@@ -44,3 +46,15 @@ def is_unit(xblock):
     """
 
     return get_parent_unit(xblock) is None and xblock.get_parent()
+
+
+def use_learning_legacy_frontend() -> bool:
+    """
+    Checks in django settings if use the learning legacy
+    frontend instead the learning mfe.
+
+    Returns:
+        True if the legacy frontend setting is activated, by default
+        legacy would be activated.
+    """
+    return bool(getattr(settings, "USE_LEARNING_LEGACY_FRONTEND", True))

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -125,7 +125,7 @@ openedx-filters                     # Open edX Filters from Hooks Extension Fram
 ora2
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo                              # Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
 pycountry
 pycryptodomex
 pygments                            # Used to support colors in paver command output

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -781,7 +781,7 @@ psutil==5.9.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1061,7 +1061,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -998,7 +998,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This is a cherry-pick from #733 to allow learning MFE by Tenants.

## Usage
![image](https://github.com/eduNEXT/edunext-platform/assets/40800297/e00bf145-e42e-46c4-8861-2402245f2384)

## How to test
- Install eox-tenant https://github.com/eduNEXT/eox-tenant
- Create at least 2 tenants to test it.
- If you will test this in an stage environment, and you want to use MFE's by path like the picture, you should install https://github.com/eduNEXT/tutor-contrib-mfe-extensions/tree/master
- If you are not using MFE's by path, it means you have one main site apps.*, you should create a tenant without course filter for the main site.
- Set the next two waffle flags: **course_home.course_home_use_legacy_frontend** and **courseware.use_legacy_frontend**
- Add the next settings to the Tenant that will use MFEs:
  - LEARNING_MICROFRONTEND_URL
  - course_org_filter
  - USE_LEARNING_LEGACY_FRONTEND in **False**
  - `"MFE_CONFIG": {
    "LMS_BASE_URL": "https://tenant-b.nutmeg-live.edunext.link",
    "LOGIN_URL": "https://tenant-b.nutmeg-live.edunext.link/login",
    "LOGOUT_URL": "https://tenant-b.nutmeg-live.edunext.link/logout",
    "REFRESH_ACCESS_TOKEN_ENDPOINT": "https://tenant-b.nutmeg-live.edunext.link/login_refresh"
},`
- If you visit a course in the tenant that has the setting USE_LEARNING_LEGACY_FRONTEND in False, you should see the learning MFE, otherwise you should see the legacy frontend.

## Where was it tested?
- [x] tested in stage with https://tenant-b.nutmeg-live.edunext.link and  https://tenant-c.nutmeg-live.edunext.link