### PR TITLE
fix: first language visit

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -2,7 +2,7 @@
 Middleware for Language Preferences
 """
 
-
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation.trans_real import parse_accept_lang_header
@@ -29,7 +29,7 @@ class LanguagePreferenceMiddleware(MiddlewareMixin):
         If a user's UserPreference contains a language preference, use the user's preference.
         Save the current language preference cookie as the user's preferred language.
         """
-        cookie_lang = lang_pref_helpers.get_language_cookie(request)
+        cookie_lang = lang_pref_helpers.get_language_cookie(request, getattr(settings, "LANGUAGE_CODE", None))
         if cookie_lang:
             if request.user.is_authenticated:
                 # DarkLangMiddleware will take care of this so don't change anything


### PR DESCRIPTION


<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This fix is based in the method `get_language_cookie` default value. https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/lang_pref/helpers.py#L9

So in the first visit if the cookie doesnt exist, the language would be the configure by settings using `LANGUAGE_CODE`.If it is not defined, then would be `None` that is the default of the method.

## Supporting information

Jira ticket:
https://edunext.atlassian.net/jira/software/c/projects/FUTUREX/boards/36?selectedIssue=FUTUREX-640

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.


