### PR TITLE
feat: control linked account by settings (#675)

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -13,6 +13,7 @@
         return function(
             fieldsData,
             disableOrderHistoryTab,
+            showLinkedAccountsTab,
             ordersHistoryData,
             authData,
             passwordResetSupportUrl,
@@ -439,6 +440,7 @@
                 },
                 userPreferencesModel: userPreferencesModel,
                 disableOrderHistoryTab: disableOrderHistoryTab,
+                showLinkedAccountsTab: showLinkedAccountsTab,
                 betaLanguage: betaLanguage
             });
 

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -37,15 +37,18 @@
                         selected: true,
                         expanded: true
                     },
-                    {
+                ];
+
+                if (view.options.showLinkedAccountsTab) {
+                    accountSettingsTabs.push({
                         name: 'accountsTabSections',
                         id: 'accounts-tab',
                         label: gettext('Linked Accounts'),
                         tabindex: -1,
                         selected: false,
                         expanded: false
-                    }
-                ];
+                    });
+                }
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({
                         name: 'ordersTabSections',

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -53,6 +53,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
     AccountSettingsFactory(
         fieldsData,
         ${ disable_order_history_tab | n, dump_js_escaped_json },
+        ${ show_linked_accounts_tab | n, dump_js_escaped_json },
         ordersHistoryData,
         authData,
         '${ password_reset_support_link | n, js_escaped_string }',

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -30,7 +30,8 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
-    should_redirect_to_order_history_microfrontend
+    should_redirect_to_order_history_microfrontend,
+    should_show_linked_accounts_tab
 )
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.edx_api_utils import get_api_data
@@ -159,6 +160,7 @@ def account_settings_context(request):
         'show_dashboard_tabs': True,
         'order_history': user_orders,
         'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -26,6 +26,13 @@ def should_redirect_to_order_history_microfrontend():
     )
 
 
+def should_show_linked_accounts_tab():
+    """Check if the the var `SHOW_LINKED_ACCOUNTS`
+        is defined in configuration helpers.
+    """
+    return configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
+
+
 # .. toggle_name: account.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False


### PR DESCRIPTION


<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
Migration to palm


* feat: control linked account by settings

This feature allows to control the tab linked_accounts in account settings to appear or not. Is controlled using `SHOW_LINKED_ACCOUNTS`

(cherry picked from commit 7d43718042414d4e736d1c225cb9008c363dfbd3) (cherry picked from commit 6fef8d1ca7efe1b87602a764a8cbe62c880f623b)

* feat: PR improvements

- doblequotes for dosctring
- avoid jump of line if its not necessary

(cherry picked from commit ae27a1527073664a930b2bfdfee48ff801416d95)

## Testing instructions
### Deactivate mfe account settings. This change is only for the base or classic account settings view. Mfe doesnt works.

Deactivate via the django waffle flag or  using django site config or eox-tenant if you have it.
`SHOW_LINKED_ACCOUNTS = False
`
https://github.com/eduNEXT/edunext-platform/blob/ednx-release/palma.master.nelp/openedx/core/djangoapps/user_api/accounts/toggles.py#L42

Check the linked account in the `/account/settings/` view is not presented.

### Before

![before-linked](https://github.com/eduNEXT/edunext-platform/assets/51926076/ee0f4898-cae7-48d0-a7b8-992b57a0d46a)

### AFter
![image](https://github.com/eduNEXT/edunext-platform/assets/51926076/2df6b9da-3953-48af-b9fa-a2cfc2ef8cc3)


Please provide detailed step-by-step instructions for testing this change.

