### PR TITLE
Fix signature view in certificates on honor mode

### DIFF
--- a/lms/static/certificates/sass/_components.scss
+++ b/lms/static/certificates/sass/_components.scss
@@ -501,7 +501,7 @@
     // hide the fancy
     .accomplishment-signatories .signatory-signature,
     .accomplishment-type-symbol {
-      display: none;
+      display: block;
     }
   }
 }

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -48,7 +48,7 @@ course_mode_class = course_mode if course_mode else ''
                                 % for signatory in certificate_data.get('signatories', []):
                                     % if signatory.get('signature_image_path'):
                                         <div class="signatory">
-                                            <img class="" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
+                                            <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
 
                                             <h4 class="signatory-name hd-5">${signatory['name']}</h4>
                                             <p class="signatory-credentials copy copy-micro">

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%! from django.utils.translation import gettext as _ %>
-<%namespace name='static' file='../static_content.html'/>
+<%namespace name='static' file='/static_content.html'/>
 <%
 course_mode_class = course_mode if course_mode else ''
 %>
@@ -48,7 +48,7 @@ course_mode_class = course_mode if course_mode else ''
                                 % for signatory in certificate_data.get('signatories', []):
                                     % if signatory.get('signature_image_path'):
                                         <div class="signatory">
-                                            <img class="" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
+                                            <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
 
                                             <h4 class="signatory-name hd-5">${signatory['name']}</h4>
                                             <p class="signatory-credentials copy copy-micro">

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -48,7 +48,7 @@ course_mode_class = course_mode if course_mode else ''
                                 % for signatory in certificate_data.get('signatories', []):
                                     % if signatory.get('signature_image_path'):
                                         <div class="signatory">
-                                            <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
+                                            <img class="" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
 
                                             <h4 class="signatory-name hd-5">${signatory['name']}</h4>
                                             <p class="signatory-credentials copy copy-micro">

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -1,6 +1,6 @@
 <%page expression_filter="h"/>
 <%! from django.utils.translation import gettext as _ %>
-<%namespace name='static' file='/static_content.html'/>
+<%namespace name='static' file='../static_content.html'/>
 <%
 course_mode_class = course_mode if course_mode else ''
 %>


### PR DESCRIPTION


## Description

In the Olmo version the signature does not appear in the certificates, this was reported https://github.com/openedx/wg-build-test-release/issues/177#issuecomment-1124246022 apparently you can only see the signatures when the course is in verified mode. However by placing a block to a display that prevents the signatures and header image of the certificate from being displayed. 
![image](https://github.com/eduNEXT/edunext-platform/assets/39286595/cffd144d-fe9b-4da9-af03-1109b5c134b7)


## Supporting information

Jira task: https://edunext.atlassian.net/jira/software/c/projects/SD/boards/44?assignee=64074f0993cf25994630355f&selectedIssue=SD-2023
