### PR TITLE
feat: add a new tenant setting to enable the Course Authoring MFE

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -643,7 +643,10 @@ class TestCourseOutline(CourseTestCase):
             expected_block_types
         )
 
-    @override_settings(FEATURES={'ENABLE_EXAM_SETTINGS_HTML_VIEW': True})
+    @override_settings(FEATURES={
+        'ENABLE_EXAM_SETTINGS_HTML_VIEW': True,
+        'ENABLE_MFE_FOR_TESTING': True
+    })
     @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings')
     def test_proctoring_link_is_visible(self, mock_validate_proctoring_settings):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -19,6 +19,7 @@ FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 FEATURES_WITH_EXAM_SETTINGS_ENABLED = FEATURES_WITH_CERTS_ENABLED.copy()
 FEATURES_WITH_EXAM_SETTINGS_ENABLED['ENABLE_EXAM_SETTINGS_HTML_VIEW'] = True
 FEATURES_WITH_EXAM_SETTINGS_ENABLED['ENABLE_PROCTORED_EXAMS'] = True
+FEATURES_WITH_EXAM_SETTINGS_ENABLED['ENABLE_MFE_FOR_TESTING'] = True
 
 FEATURES_WITH_EXAM_SETTINGS_DISABLED = FEATURES_WITH_CERTS_ENABLED.copy()
 FEATURES_WITH_EXAM_SETTINGS_DISABLED['ENABLE_EXAM_SETTINGS_HTML_VIEW'] = False
@@ -179,7 +180,10 @@ class TestExamSettingsView(CourseTestCase, UrlResetMixin):
         alert_nodes = parsed_html.find_class('exam-settings-alert')
         assert len(alert_nodes) == 0
 
-    @override_settings(FEATURES={'ENABLE_EXAM_SETTINGS_HTML_VIEW': True})
+    @override_settings(FEATURES={
+        'ENABLE_EXAM_SETTINGS_HTML_VIEW': True,
+        'ENABLE_MFE_FOR_TESTING': True
+    })
     @patch('cms.djangoapps.models.settings.course_metadata.CourseMetadata.validate_proctoring_settings')
     def test_proctoring_link_is_visible(self, mock_validate_proctoring_settings):
 

--- a/cms/lib/utils.py
+++ b/cms/lib/utils.py
@@ -1,0 +1,26 @@
+"""
+Helper methods for the CMS.
+"""
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from edx_toggles.toggles import SettingDictToggle
+
+
+def use_course_authoring_mfe(org) -> bool:
+    """
+    Checks with the org if the tenant enables the
+    Course Authoring MFE.
+    Returns:
+        True if the MFE setting is activated, by default
+        the MFE is deactivated
+    """
+
+    ENABLE_MFE_FOR_TESTING = SettingDictToggle(
+        "FEATURES", "ENABLE_MFE_FOR_TESTING", default=False, module_name=__name__
+    ).is_enabled()
+
+    use_microfrontend = configuration_helpers.get_value_for_org(
+        org, "ENABLE_COURSE_AUTHORING_MFE", ENABLE_MFE_FOR_TESTING or False
+    )
+
+    return bool(use_microfrontend)

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -8,11 +8,12 @@ from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
 from cms.djangoapps.contentstore.toggles import use_new_text_editor, use_new_problem_editor, use_new_video_editor
+from cms.lib.utils import use_course_authoring_mfe
 %>
 <%
-use_new_editor_text = use_new_text_editor()
-use_new_editor_video = use_new_video_editor()
-use_new_editor_problem = use_new_problem_editor()
+use_new_editor_text = use_course_authoring_mfe(xblock.location.course_key.org) and use_new_text_editor()
+use_new_editor_video = use_course_authoring_mfe(xblock.location.course_key.org) and use_new_video_editor()
+use_new_editor_problem = use_course_authoring_mfe(xblock.location.course_key.org) and use_new_problem_editor()
 xblock_url = xblock_studio_url(xblock)
 show_inline = xblock.has_children and not xblock_url
 section_class = "level-nesting" if show_inline else "level-element"

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -12,6 +12,7 @@
   from cms.djangoapps.contentstore.utils import get_pages_and_resources_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
+  from cms.lib.utils import use_course_authoring_mfe
 %>
 <div class="wrapper-header wrapper" id="view-top">
   <header class="primary" role="banner">
@@ -45,7 +46,7 @@
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
+            pages_and_resources_mfe_enabled = use_course_authoring_mfe(course_key.org) and ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>


### PR DESCRIPTION
# Depends on

- eox-tenant PR https://github.com/eduNEXT/eox-tenant/pull/197 where are applied some changes to manage `boolean` values in the tenants 
- ednx-saas-themes PR https://github.com/eduNEXT/ednx-saas-themes/pull/201 where is applied the `use_course_authoring_mfe` util to the required template

## Description

This PR creates a handler for a new setting `ENABLE_COURSE_AUTHORING_MFE` that will allow to enable or disable the course authoring MFE according to the settings of the tenant

For you to take it into account, there is a [set of tests failing](https://github.com/eduNEXT/edunext-platform/actions/runs/8085851923/job/22094291959?pr=808) that doesn't belong to the changes applied in this PR. Next, I let evidence of the tests ran in the base release branch `ednx-release/palma.master` and they are even failing there:

![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/8f0f7287-ccb2-445f-a8a7-154d9e6a64ea)


## Supporting information

[JIRA Issue DS-805](https://edunext.atlassian.net/browse/DS-805?atlOrigin=eyJpIjoiOTNkNzZmM2JkZmEzNGFmYzk0NDllYTlhMjQ5ZGFhMjQiLCJwIjoiaiJ9)

## Testing instructions
### Local
1. Run a Palm environment using [TVM](https://tvm.docs.edunext.co/en/latest/tvm_quickstart.html#step-by-step) or the [Tutor docs](https://docs.tutor.edly.io/install.html) in its [Palm version](https://pypi.org/project/tutor/16.1.8/)
2. Use this branch as your edx-platform version adding in the config.yml the following
  ``` yml
  EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edunext-platform.git
  EDX_PLATFORM_VERSION: bc/enable_course_authoring_setting
  ```
3. Install tutor-mfe directly in the Tutor environment `tutor plugins install mfe`, and enable it `tutor plugins enable mfe`
4. Update the environment settings `tutor config save` to make the two above bullets available
5. Clone the eox-tenant repository, git-checkout it to [this branch](https://github.com/eduNEXT/eox-tenant/pull/197), add it to your LMS and CMS `tutor mounts add lms,cms:/path/to/eox-tenant/clone:/openedx/extra-deps/eox-tenant` 
6. Init the environment again to install the MFE container, use the new edx-platform version and add the eox-tenant to the LMS+CMS containers `tutor dev/local launch`
7. Go to both container `tutor dev exec lms/cms bash`, install eox-tenant `pip install -e .../extra-deps/eox-tenant`, and run the migrations `./manage.py lms makemigrations` and `./manage.py lms migrate`
8. Restart the containers `tutor dev restart`
9. Go to the admin panel and create 2 new routes:
  - **Domain name:** tenant-a.local.overhang.io
    ``` json
    {
        "COURSE_AUTHORING_MICROFRONTEND_URL": "http://apps.tenant-a.local.overhang.io:2001/course-authoring",
        "EDNX_USE_SIGNAL": true,
        "ENABLE_COURSE_AUTHORING_MFE": true,
        "LMS_BASE": "tenant-a.local.overhang.io:8000",
        "LMS_ROOT_URL": "http://tenant-a.local.overhang.io:8000",
        "MFE_CONFIG": {
            "EXAMS_BASE_URL": "",
            "LMS_BASE_URL": "http://tenant-a.local.overhang.io",
            "LOGIN_URL": "http://tenant-a.local.overhang.io/login",
            "LOGOUT_URL": "http://tenant-a.local.overhang.io/logout"
        },
        "PLATFORM_NAME": "Tenant A",
        "SITE_NAME": "tenant-a.local.overhang.io",
        "course_org_filter": [
            "tenantA"
        ]
    }
    ```
  - **Domain name:** tenant-b.local.overhang.io
    ``` json
    {
        "COURSE_AUTHORING_MICROFRONTEND_URL": "http://apps.tenant-b.local.overhang.io:2001/course-authoring",
        "EDNX_USE_SIGNAL": true,
        "ENABLE_COURSE_AUTHORING_MFE": false,
        "LMS_BASE": "tenant-b.local.overhang.io:8000",
        "LMS_ROOT_URL": "http://tenant-b.local.overhang.io:8000",
        "MFE_CONFIG": {
            "EXAMS_BASE_URL": "",
            "LMS_BASE_URL": "http://tenant-b.local.overhang.io",
            "LOGIN_URL": "http://tenant-b.local.overhang.io/login",
            "LOGOUT_URL": "http://tenant-b.local.overhang.io/logout"
        },
        "PLATFORM_NAME": "Tenant B",
        "SITE_NAME": "tenant-b.local.overhang.io",
        "course_org_filter": [
            "tenantB"
        ]
    }  
    ```
10. Go to Studio and create two new courses one of them with the organization `tenantA` and the other one with the organization `tenantB` 
11. If everything went okay, once you access to the 'tenantA' course you have to see something like this pointing to the tenant-a (if you click it)

![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/081bde3a-9945-4752-b078-d5e29618b1d6)

12. Now if you go to the 'tenantB' course, because of the flag `ENABLE_COURSE_AUTHORING: false`, you have to see the legacy 'Pages' section...

![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/dc1bef38-0d38-40fd-9e50-019a0dcb4d45)

... but, if you have the flag as `ENABLE_COURSE_AUTHORING: true`, then you'll see the MFE directioner, but this will point to the tenant-b 

![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/bab600a6-35bd-4ca3-93b2-cd303a0d49f0)

13. Additionally, having the ENABLE_COURSE_AUTHORING_MFE as true, if you are adding a new component in a unit, the options 'Text', 'Video', and 'Problem' should send you to a route with course-authoring

![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/f1f832fc-572c-4f26-a93b-a47a28054cf9)
![image](https://github.com/eduNEXT/edunext-platform/assets/86393372/1a5945c6-c31b-47fc-8998-17935748526a)

### Stage
First, meanwhile the PRs are approved, make sure that the 'TARGET REVISION' in ArgoCD is pointing to the branch 
`bc/test_course_authoring_setting` of the manifest

![image](https://github.com/eduNEXT/ednx-saas-themes/assets/86393372/c2238d73-073c-40ed-a024-cf38aea087ec)

Then make sure there are tenant configs one with `ENABLE_COURSE_AUTHORING_MFE=true` and another with `false` and start testing from 11 bullet in the above section