### PR TITLE
feat: create a new setting USE_DISCUSSIONS_MFE

### DIFF
--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -839,7 +839,7 @@ class DiscussionLinkTestCase(TabTestCase):
         else:
             expected_link = reverse("forum_form_discussion", args=[str(self.course.id)])
 
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True, 'ENABLE_MFE_FOR_TESTING': True}):
             with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, toggle_enabled):
                 self.check_discussion(
                     tab_list=self.tabs_with_discussion,

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_noop
 
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
 from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
+from openedx.core.djangoapps.discussions.utils import use_discussions_mfe
 from xmodule.tabs import TabFragmentViewMixin
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
@@ -44,7 +45,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
     @property
     def link_func(self):
         def _link_func(course, reverse_func):
-            if ENABLE_DISCUSSIONS_MFE.is_enabled(course.id):
+            if ENABLE_DISCUSSIONS_MFE.is_enabled(course.id) and use_discussions_mfe(course.org):
                 return get_discussions_mfe_url(course_key=course.id)
             return reverse('forum_form_discussion', args=[str(course.id)])
 

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -41,7 +41,10 @@ from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE, ENABLE_LEA
 from lms.djangoapps.discussion.toggles_utils import reported_content_email_notification_enabled
 from lms.djangoapps.discussion.views import is_privileged_user
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration, DiscussionTopicLink, Provider
-from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
+from openedx.core.djangoapps.discussions.utils import (
+    get_accessible_discussion_xblocks,
+    use_discussions_mfe
+)
 from openedx.core.djangoapps.django_comment_common import comment_client
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.course import (
@@ -1351,7 +1354,7 @@ def _handle_abuse_flagged_field(form_value, user, cc_content, request):
     if form_value:
         cc_content.flagAbuse(user, cc_content)
         track_discussion_reported_event(request, course, cc_content)
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and reported_content_email_notification_enabled(
+        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and use_discussions_mfe(course.org) and reported_content_email_notification_enabled(
                 course_key):
             if cc_content.type == 'thread':
                 thread_flagged.send(sender='flag_abuse_for_thread', user=user, post=cc_content)

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -1354,8 +1354,9 @@ def _handle_abuse_flagged_field(form_value, user, cc_content, request):
     if form_value:
         cc_content.flagAbuse(user, cc_content)
         track_discussion_reported_event(request, course, cc_content)
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and use_discussions_mfe(course.org) and reported_content_email_notification_enabled(
-                course_key):
+        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and use_discussions_mfe(
+                course.org) and reported_content_email_notification_enabled(
+                    course_key):
             if cc_content.type == 'thread':
                 thread_flagged.send(sender='flag_abuse_for_thread', user=user, post=cc_content)
             else:

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2280,8 +2280,8 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
     Tests that the MFE upgrade banner and MFE is shown in the correct situation with the correct UI
     """
 
-    features_with_enable_mfe_settings = settings.FEATURES.copy()
-    features_with_enable_mfe_settings['ENABLE_MFE_FOR_TESTING'] = True
+    FEATURES_WITH_DISCUSSION_MFE_ENABLED = settings.FEATURES.copy()
+    FEATURES_WITH_DISCUSSION_MFE_ENABLED['ENABLE_MFE_FOR_TESTING'] = True
 
     def setUp(self):
         super().setUp()
@@ -2290,7 +2290,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.staff_user = AdminFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_base_url_to_new_experience(self):
         """
         Verify that the legacy url is redirected to MFE homepage when
@@ -2305,7 +2305,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_profile_url_to_new_experience(self):
         """
         Verify that the requested user profile is redirected to MFE learners tab when
@@ -2320,7 +2320,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/learners"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_single_thread_to_new_experience(self):
         """
         Verify that a legacy single url is redirected to corresponding MFE thread url when the ENABLE_DISCUSSIONS_MFE

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2287,7 +2287,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.staff_user = AdminFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
     def test_redirect_from_legacy_base_url_to_new_experience(self):
         """
         Verify that the legacy url is redirected to MFE homepage when
@@ -2302,7 +2302,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
     def test_redirect_from_legacy_profile_url_to_new_experience(self):
         """
         Verify that the requested user profile is redirected to MFE learners tab when
@@ -2317,7 +2317,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/learners"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
     def test_redirect_from_legacy_single_thread_to_new_experience(self):
         """
         Verify that a legacy single url is redirected to corresponding MFE thread url when the ENABLE_DISCUSSIONS_MFE

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2287,7 +2287,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.staff_user = AdminFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
     def test_redirect_from_legacy_base_url_to_new_experience(self):
         """
         Verify that the legacy url is redirected to MFE homepage when
@@ -2302,7 +2302,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
     def test_redirect_from_legacy_profile_url_to_new_experience(self):
         """
         Verify that the requested user profile is redirected to MFE learners tab when
@@ -2317,7 +2317,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/learners"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND="true")
     def test_redirect_from_legacy_single_thread_to_new_experience(self):
         """
         Verify that a legacy single url is redirected to corresponding MFE thread url when the ENABLE_DISCUSSIONS_MFE

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2281,7 +2281,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
     """
 
     features_with_enable_mfe_settings = settings.FEATURES.copy()
-    features_with_enable_mfe_settings['ENABLE_MFE_FOR_TESTING']=True
+    features_with_enable_mfe_settings['ENABLE_MFE_FOR_TESTING'] = True
 
     def setUp(self):
         super().setUp()

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2280,6 +2280,9 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
     Tests that the MFE upgrade banner and MFE is shown in the correct situation with the correct UI
     """
 
+    features_with_enable_mfe_settings = settings.FEATURES.copy()
+    features_with_enable_mfe_settings['ENABLE_MFE_FOR_TESTING']=True
+
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
@@ -2287,7 +2290,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.staff_user = AdminFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
     def test_redirect_from_legacy_base_url_to_new_experience(self):
         """
         Verify that the legacy url is redirected to MFE homepage when
@@ -2302,7 +2305,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
     def test_redirect_from_legacy_profile_url_to_new_experience(self):
         """
         Verify that the requested user profile is redirected to MFE learners tab when
@@ -2317,7 +2320,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/learners"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", USE_DISCUSSIONS_MFE_FRONTEND=True)
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=features_with_enable_mfe_settings)
     def test_redirect_from_legacy_single_thread_to_new_experience(self):
         """
         Verify that a legacy single url is redirected to corresponding MFE thread url when the ENABLE_DISCUSSIONS_MFE

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -655,8 +655,9 @@ def user_profile(request, course_key, user_id):
                 'annotated_content_info': context['annotated_content_info'],
             })
         else:
+            course = get_course_with_access(request.user, 'load', course_key)
             discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
-            if discussions_mfe_enabled:
+            if discussions_mfe_enabled and use_discussions_mfe(course.org):
                 mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
                 return redirect(f"{mfe_base_url}/{str(course_key)}/learners")
 

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -334,7 +334,7 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
-    
+
     if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         if thread_id:

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -54,7 +54,8 @@ from openedx.core.djangoapps.discussions.utils import (
     available_division_schemes,
     get_discussion_categories_ids,
     get_divided_discussions,
-    get_group_names_by_id
+    get_group_names_by_id,
+    use_discussions_mfe
 )
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -271,9 +272,10 @@ def redirect_forum_url_to_new_mfe(request, course_id):
     """
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
+    course = get_course_with_access(request.user, 'load', course_key)
 
     redirect_url = None
-    if discussions_mfe_enabled:
+    if discussions_mfe_enabled and use_discussions_mfe(course.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         redirect_url = f"{mfe_base_url}/{str(course_key)}"
     return redirect_url
@@ -333,7 +335,8 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
-    if discussions_mfe_enabled:
+    course = get_course_with_access(request.user, 'load', course_key)
+    if discussions_mfe_enabled and use_discussions_mfe(course.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         if thread_id:
             redirect_url = f"{mfe_base_url}/{str(course_key)}/posts/{thread_id}"

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -272,10 +272,9 @@ def redirect_forum_url_to_new_mfe(request, course_id):
     """
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
-    course = get_course_with_access(request.user, 'load', course_key)
 
     redirect_url = None
-    if discussions_mfe_enabled and use_discussions_mfe(course.org):
+    if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         redirect_url = f"{mfe_base_url}/{str(course_key)}"
     return redirect_url
@@ -335,8 +334,8 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
-    course = get_course_with_access(request.user, 'load', course_key)
-    if discussions_mfe_enabled and use_discussions_mfe(course.org):
+    
+    if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         if thread_id:
             redirect_url = f"{mfe_base_url}/{str(course_key)}/posts/{thread_id}"
@@ -655,9 +654,8 @@ def user_profile(request, course_key, user_id):
                 'annotated_content_info': context['annotated_content_info'],
             })
         else:
-            course = get_course_with_access(request.user, 'load', course_key)
             discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
-            if discussions_mfe_enabled and use_discussions_mfe(course.org):
+            if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
                 mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
                 return redirect(f"{mfe_base_url}/{str(course_key)}/learners")
 

--- a/openedx/core/djangoapps/discussions/utils.py
+++ b/openedx/core/djangoapps/discussions/utils.py
@@ -202,8 +202,8 @@ def use_discussions_mfe(org) -> bool:
         True if the MFE setting is activated, by default
         the MFE is deactivated
     """
-    use_discussions_mfe = configuration_helpers.get_value_for_org(
+    use_discussions = configuration_helpers.get_value_for_org(
         org, "USE_DISCUSSIONS_MFE_FRONTEND", False
     )
 
-    return bool(use_discussions_mfe)
+    return bool(use_discussions)

--- a/openedx/core/djangoapps/discussions/utils.py
+++ b/openedx/core/djangoapps/discussions/utils.py
@@ -208,7 +208,7 @@ def use_discussions_mfe(org) -> bool:
     ).is_enabled()
 
     use_discussions = configuration_helpers.get_value_for_org(
-        org, "USE_DISCUSSIONS_MFE_FRONTEND", ENABLE_MFE_FOR_TESTING or False
+        org, "USE_DISCUSSIONS_MFE", ENABLE_MFE_FOR_TESTING or False
     )
 
     return bool(use_discussions)

--- a/openedx/core/djangoapps/discussions/utils.py
+++ b/openedx/core/djangoapps/discussions/utils.py
@@ -17,6 +17,7 @@ from xmodule.course_block import CourseBlock  # lint-amnesty, pylint: disable=wr
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions_service import PartitionService  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 log = logging.getLogger(__name__)
 
@@ -191,3 +192,18 @@ def get_course_division_scheme(course_discussion_settings: CourseDiscussionSetti
     ):
         division_scheme = CourseDiscussionSettings.NONE
     return division_scheme
+
+
+def use_discussions_mfe(org) -> bool:
+    """
+    Checks with the org if the tenant enables the
+    Discussions MFE.
+    Returns:
+        True if the MFE setting is activated, by default
+        the MFE is deactivated
+    """
+    use_discussions_mfe = configuration_helpers.get_value_for_org(
+        org, "USE_DISCUSSIONS_MFE_FRONTEND", False
+    )
+
+    return bool(use_discussions_mfe)

--- a/openedx/core/djangoapps/discussions/utils.py
+++ b/openedx/core/djangoapps/discussions/utils.py
@@ -18,6 +18,7 @@ from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disa
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions_service import PartitionService  # lint-amnesty, pylint: disable=wrong-import-order
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from edx_toggles.toggles import SettingDictToggle
 
 log = logging.getLogger(__name__)
 
@@ -202,8 +203,12 @@ def use_discussions_mfe(org) -> bool:
         True if the MFE setting is activated, by default
         the MFE is deactivated
     """
+    ENABLE_MFE_FOR_TESTING = SettingDictToggle(
+        "FEATURES", "ENABLE_MFE_FOR_TESTING", default=False, module_name=__name__
+    ).is_enabled()
+
     use_discussions = configuration_helpers.get_value_for_org(
-        org, "USE_DISCUSSIONS_MFE_FRONTEND", False
+        org, "USE_DISCUSSIONS_MFE_FRONTEND", ENABLE_MFE_FOR_TESTING or False
     )
 
     return bool(use_discussions)


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This PR adds a new setting `USE_DISCUSSIONS_MFE` that will allow Discussions MFE to be enabled or disabled in the tenant

## Supporting information

[JIRA Issue DS-806](https://edunext.atlassian.net/browse/DS-806)

## Testing instructions

1. Run a Palm environment using [TVM](https://tvm.docs.edunext.co/en/latest/tvm_quickstart.html#step-by-step) or the [Tutor docs](https://docs.tutor.edly.io/install.html) in its [Palm version](https://pypi.org/project/tutor/16.1.8/)
2. Use this branch as your edx-platform version adding in the config.yml the following
  ``` yml
  EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edunext-platform.git
  EDX_PLATFORM_VERSION: lfc/enable-discussions-mfe
  ```
3. Install tutor-mfe directly in the Tutor environment `tutor plugins install mfe`, and enable it `tutor plugins enable mfe` 
4. `tutor plugins install forum`
5. Update the environment settings `tutor config save`
6. `tutor dev launch`
7. Go to both container `tutor dev exec lms/cms bash`, install eox-tenant `pip install eox-tenant`, and run the migrations `./manage.py lms makemigrations` and `./manage.py lms migrate`
8. Restart the containers `tutor dev restart`
9. Go to the admin panel and create 2 new routes:
  - **Domain name:** site1.local.overhang.io
    ``` json
    {
        "DISCUSSIONS_MICROFRONTEND_URL": "http://site1.local.overhang.io:2002/discussions",
        "EDNX_USE_SIGNAL": true,
        "LEARNING_MICROFRONTEND_URL": "http://site1.local.overhang.io:2000/learning",
        "LMS_BASE": "site1.local.overhang.io:8000",
        "LMS_ROOT_URL": "http://site1.local.overhang.io:8000",
        "MFE_CONFIG": {
            "EXAMS_BASE_URL": "",
            "LMS_BASE_URL": "http://site1.local.overhang.io",
            "LOGIN_URL": "http://site1.local.overhang.io/login",
            "LOGOUT_URL": "http://site1.local.overhang.io/logout"
        },
        "PLATFORM_NAME": "site1",
        "SITE_NAME": "site1.local.overhang.io",
        "USE_DISCUSSIONS_MFE": false,
        "course_org_filter": [
            "site1"
        ]
    }
    ```
  - **Domain name:** site2.local.overhang.io
    ``` json
    {
        "DISCUSSIONS_MICROFRONTEND_URL": "http://site2.local.overhang.io:2002/discussions",
        "EDNX_USE_SIGNAL": true,
        "LEARNING_MICROFRONTEND_URL": "http://site2.local.overhang.io:2000/learning",
        "LMS_BASE": "site2.local.overhang.io:8000",
        "LMS_ROOT_URL": "http://site2.local.overhang.io:8000",
        "MFE_CONFIG": {
            "EXAMS_BASE_URL": "",
            "LMS_BASE_URL": "http://site2.local.overhang.io",
            "LOGIN_URL": "http://site2.local.overhang.io/login",
            "LOGOUT_URL": "http://site2.local.overhang.io/logout"
        },
        "PLATFORM_NAME": "site2",
        "SITE_NAME": "site2.local.overhang.io",
        "USE_DISCUSSIONS_MFE": true,
        "course_org_filter": [
            "site2"
        ]
    }
    ```
10. Go to Studio and create two new courses one of them with the organization `site1` and the other one with the organization `site2`
11. Go to http://site1.local.overhang.io:8000/dashboard and clic on "Resume Course"
12. Install CORS Everywhere Extension to prevent CORS error.
13.  Clic on "Discussions" Tab
14.  If USE_DISCUSSIONS_MFE: true:
![image](https://github.com/eduNEXT/edunext-platform/assets/78836902/413f3409-7e38-4902-9cfd-61543828ff01)
15. If  USE_DISCUSSIONS_MFE: false:
![image](https://github.com/eduNEXT/edunext-platform/assets/78836902/7be7eeab-da8a-4578-8cb5-a4ffecfee3f6)

