### PR TITLE
fix: downgrading lti consumer as current version is not compatible

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -647,7 +647,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==7.3.0
+lti-consumer-xblock==7.2.3
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via


### PR DESCRIPTION
The actual version of the LTI consumer is not supported by the nutmeg version of the platform as some files had been renamed, these changes are required.

So as part of the solution, we need to downgrade the version of the LTI consumer to get this xblock is compatible with the nutmeg open edX version.

This change was implemented in the update from 7.3.0 to 7.2.3

https://github.com/openedx/xblock-lti-consumer/compare/7.2.3...7.3.0

The change in the edunext-platform repository were made in the following commit, this commit is present since palm version

https://github.com/eduNEXT/edunext-platform/commit/9d8375ff99f999e4c09220d85df368c78bb14bce

This incompatibility is generating an error at the moment that the component tries to update the grades.