### PR TITLE
fix: fixing some broken dependencies in LTI xblock

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -647,7 +647,7 @@ libsass==0.10.0
     #   ora2
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==7.2.3
+lti-consumer-xblock==6.4.0
     # via -r requirements/edx/base.in
 lxml==4.5.0
     # via


### PR DESCRIPTION
This PR aims to downgrade the lti-consumer-xblock to version 6.4.0 to avoid some issues when this xblock tries to update the grade.