### PR TITLE
feat: create a new setting USE_DISCUSSIONS_MFE (#809)

### DIFF
--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -839,7 +839,7 @@ class DiscussionLinkTestCase(TabTestCase):
         else:
             expected_link = reverse("forum_form_discussion", args=[str(self.course.id)])
 
-        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True}):
+        with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': True, 'ENABLE_MFE_FOR_TESTING': True}):
             with override_waffle_flag(ENABLE_DISCUSSIONS_MFE, toggle_enabled):
                 self.check_discussion(
                     tab_list=self.tabs_with_discussion,

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_noop
 from lms.djangoapps.discussion.toggles import ENABLE_DISCUSSIONS_MFE
 from openedx.core.djangoapps.discussions.models import DiscussionsConfiguration
 from openedx.core.djangoapps.discussions.url_helpers import get_discussions_mfe_url
+from openedx.core.djangoapps.discussions.utils import use_discussions_mfe
 from xmodule.tabs import TabFragmentViewMixin
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
@@ -47,7 +48,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
     @property
     def link_func(self):
         def _link_func(course, reverse_func):
-            if ENABLE_DISCUSSIONS_MFE.is_enabled(course.id):
+            if ENABLE_DISCUSSIONS_MFE.is_enabled(course.id) and use_discussions_mfe(course.org):
                 return get_discussions_mfe_url(course_key=course.id)
             return reverse('forum_form_discussion', args=[str(course.id)])
 

--- a/lms/djangoapps/discussion/rest_api/api.py
+++ b/lms/djangoapps/discussion/rest_api/api.py
@@ -44,7 +44,10 @@ from openedx.core.djangoapps.discussions.models import (
     DiscussionTopicLink,
     Provider,
 )
-from openedx.core.djangoapps.discussions.utils import get_accessible_discussion_xblocks
+from openedx.core.djangoapps.discussions.utils import (
+    get_accessible_discussion_xblocks,
+    use_discussions_mfe
+)
 from openedx.core.djangoapps.django_comment_common import comment_client
 from openedx.core.djangoapps.django_comment_common.comment_client.comment import Comment
 from openedx.core.djangoapps.django_comment_common.comment_client.course import (
@@ -1366,7 +1369,9 @@ def _handle_abuse_flagged_field(form_value, user, cc_content, request):
     if form_value:
         cc_content.flagAbuse(user, cc_content)
         track_discussion_reported_event(request, course, cc_content)
-        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key):
+        if ENABLE_DISCUSSIONS_MFE.is_enabled(course_key) and use_discussions_mfe(
+                course.org) and reported_content_email_notification_enabled(
+                    course_key):
             if cc_content.type == 'thread':
                 thread_flagged.send(sender='flag_abuse_for_thread', user=user, post=cc_content)
             else:

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -2285,6 +2285,9 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
     Tests that the MFE upgrade banner and MFE is shown in the correct situation with the correct UI
     """
 
+    FEATURES_WITH_DISCUSSION_MFE_ENABLED = settings.FEATURES.copy()
+    FEATURES_WITH_DISCUSSION_MFE_ENABLED['ENABLE_MFE_FOR_TESTING'] = True
+
     def setUp(self):
         super().setUp()
         self.course = CourseFactory.create()
@@ -2292,7 +2295,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
         self.staff_user = AdminFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_base_url_to_new_experience(self):
         """
         Verify that the legacy url is redirected to MFE homepage when
@@ -2307,7 +2310,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_profile_url_to_new_experience(self):
         """
         Verify that the requested user profile is redirected to MFE learners tab when
@@ -2322,7 +2325,7 @@ class ForumMFETestCase(ForumsEnableMixin, SharedModuleStoreTestCase):
             expected_url = f"{settings.DISCUSSIONS_MICROFRONTEND_URL}/{str(self.course.id)}/learners"
             assert response.url == expected_url
 
-    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url")
+    @override_settings(DISCUSSIONS_MICROFRONTEND_URL="http://test.url", FEATURES=FEATURES_WITH_DISCUSSION_MFE_ENABLED)
     def test_redirect_from_legacy_single_thread_to_new_experience(self):
         """
         Verify that a legacy single url is redirected to corresponding MFE thread url when the ENABLE_DISCUSSIONS_MFE

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -54,7 +54,8 @@ from openedx.core.djangoapps.discussions.utils import (
     available_division_schemes,
     get_discussion_categories_ids,
     get_divided_discussions,
-    get_group_names_by_id
+    get_group_names_by_id,
+    use_discussions_mfe
 )
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
@@ -273,7 +274,7 @@ def redirect_forum_url_to_new_mfe(request, course_id):
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
 
     redirect_url = None
-    if discussions_mfe_enabled:
+    if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         redirect_url = f"{mfe_base_url}/{str(course_key)}"
     return redirect_url
@@ -333,7 +334,8 @@ def redirect_thread_url_to_new_mfe(request, course_id, thread_id):
     course_key = CourseKey.from_string(course_id)
     discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
     redirect_url = None
-    if discussions_mfe_enabled:
+
+    if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
         mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
         if thread_id:
             redirect_url = f"{mfe_base_url}/{str(course_key)}/posts/{thread_id}"
@@ -653,7 +655,7 @@ def user_profile(request, course_key, user_id):
             })
         else:
             discussions_mfe_enabled = ENABLE_DISCUSSIONS_MFE.is_enabled(course_key)
-            if discussions_mfe_enabled:
+            if discussions_mfe_enabled and use_discussions_mfe(course_key.org):
                 mfe_base_url = settings.DISCUSSIONS_MICROFRONTEND_URL
                 return redirect(f"{mfe_base_url}/{str(course_key)}/learners")
 

--- a/openedx/core/djangoapps/discussions/utils.py
+++ b/openedx/core/djangoapps/discussions/utils.py
@@ -17,6 +17,8 @@ from xmodule.course_block import CourseBlock  # lint-amnesty, pylint: disable=wr
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, Group  # lint-amnesty, pylint: disable=wrong-import-order
 from xmodule.partitions.partitions_service import PartitionService  # lint-amnesty, pylint: disable=wrong-import-order
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from edx_toggles.toggles import SettingDictToggle
 
 log = logging.getLogger(__name__)
 
@@ -191,3 +193,22 @@ def get_course_division_scheme(course_discussion_settings: CourseDiscussionSetti
     ):
         division_scheme = CourseDiscussionSettings.NONE
     return division_scheme
+
+
+def use_discussions_mfe(org) -> bool:
+    """
+    Checks with the org if the tenant enables the
+    Discussions MFE.
+    Returns:
+        True if the MFE setting is activated, by default
+        the MFE is deactivated
+    """
+    ENABLE_MFE_FOR_TESTING = SettingDictToggle(
+        "FEATURES", "ENABLE_MFE_FOR_TESTING", default=False, module_name=__name__
+    ).is_enabled()
+
+    use_discussions = configuration_helpers.get_value_for_org(
+        org, "USE_DISCUSSIONS_MFE", ENABLE_MFE_FOR_TESTING or False
+    )
+
+    return bool(use_discussions)


### PR DESCRIPTION
This is a backport of the Flag for enable/disable discussions MFE by tenant