### PR TITLE
feat(lms): backport support for openedx-commerce plugin to Nuez

### DIFF
--- a/openedx/core/djangoapps/enrollments/forms.py
+++ b/openedx/core/djangoapps/enrollments/forms.py
@@ -15,9 +15,10 @@ class CourseEnrollmentsApiListForm(Form):
     """
     A form that validates the query string parameters for the CourseEnrollmentsApiListView.
     """
-    MAX_USERNAME_COUNT = 100
+    MAX_INPUT_COUNT = 100
     username = CharField(required=False)
     course_id = CharField(required=False)
+    email = CharField(required=False)
 
     def clean_course_id(self):
         """
@@ -38,14 +39,31 @@ class CourseEnrollmentsApiListForm(Form):
         usernames_csv_string = self.cleaned_data.get('username')
         if usernames_csv_string:
             usernames = usernames_csv_string.split(',')
-            if len(usernames) > self.MAX_USERNAME_COUNT:
+            if len(usernames) > self.MAX_INPUT_COUNT:
                 raise ValidationError(
                     "Too many usernames in a single request - {}. A maximum of {} is allowed".format(
                         len(usernames),
-                        self.MAX_USERNAME_COUNT,
+                        self.MAX_INPUT_COUNT,
                     )
                 )
             for username in usernames:
                 validate_username(username)
             return usernames
         return usernames_csv_string
+
+    def clean_email(self):
+        """
+        Validate a string of comma-separated emails and return a list of emails.
+        """
+        emails_csv_string = self.cleaned_data.get('email')
+        if emails_csv_string:
+            emails = emails_csv_string.split(',')
+            if len(emails) > self.MAX_INPUT_COUNT:
+                raise ValidationError(
+                    "Too many emails in a single request - {}. A maximum of {} is allowed".format(
+                        len(emails),
+                        self.MAX_INPUT_COUNT,
+                    )
+                )
+            return emails
+        return emails_csv_string

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -8,7 +8,8 @@ import logging
 from rest_framework import serializers
 
 from common.djangoapps.course_modes.models import CourseMode
-from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.models import (CourseEnrollment,
+                                              CourseEnrollmentAllowed)
 
 log = logging.getLogger(__name__)
 
@@ -127,3 +128,16 @@ class ModeSerializer(serializers.Serializer):  # pylint: disable=abstract-method
     description = serializers.CharField()
     sku = serializers.CharField()
     bulk_sku = serializers.CharField()
+
+
+class CourseEnrollmentAllowedSerializer(serializers.ModelSerializer):
+    """
+    Serializes CourseEnrollmentAllowed model
+
+    Aggregates all data from the CourseEnrollmentAllowed table, and pulls in the serialization
+    to give a complete representation of course enrollment allowed.
+    """
+    class Meta:
+        model = CourseEnrollmentAllowed
+        exclude = ['id']
+        lookup_field = 'user'

--- a/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -115,6 +115,63 @@
 
     ],
     [
+        {
+            "email": "student1@example.com"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
+        {
+            "email": "student1@example.com,student2@example.com"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student1",
+                "created": "2018-01-01T00:00:01Z"
+            },
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            },
+            {
+                "course_id": "course-v1:x+y+Z",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
+        {
+            "email": "student2@example.com",
+            "course_id": "course-v1:e+d+X"
+        },
+        [
+            {
+                "course_id": "course-v1:e+d+X",
+                "is_active": true,
+                "mode": "honor",
+                "user": "student2",
+                "created": "2018-01-01T00:00:01Z"
+            }
+        ]
+    ],
+    [
         null,
         [
             {

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -235,7 +235,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                 'course_details': {
                     'course_id': str(self.course.id)
                 },
-                'user_email': self.user.email
+                'email': self.user.email
             },
             format='json'
         )
@@ -250,7 +250,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                     'course_id': str(self.course.id)
                 },
                 'user': self.user.username,
-                'user_email': 'another_email@example.com'
+                'email': 'another_email@example.com'
             },
             format='json'
         )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -294,6 +294,46 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
 
+    def test_enroll_with_user_without_permissions_and_email(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.other_user.username,
+                'email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_enroll_with_user_as_self_user(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
+    def test_enroll_without_user(self):
+        # To check if it takes the request.user.
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                }
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
     @ddt.data(
         # Default (no course modes in the database)
         # Expect that users are automatically enrolled as the default

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -1925,3 +1925,105 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
         results = content['results']
 
         self.assertCountEqual(results, expected_results)
+
+
+@ddt.ddt
+@skip_unless_lms
+class EnrollmentAllowedViewTest(APITestCase):
+    """
+    Test the view that allows the retrieval and creation of enrollment
+    allowed for a given user email and course id.
+    """
+
+    def setUp(self):
+        self.url = reverse('courseenrollmentallowed')
+        self.staff_user = AdminFactory(
+            username='staff',
+            email='staff@example.com',
+            password='edx'
+        )
+        self.student1 = UserFactory(
+            username='student1',
+            email='student1@example.com',
+            password='edx'
+        )
+        self.data = {
+            'email': 'new-student@example.com',
+            'course_id': 'course-v1:edX+DemoX+Demo_Course'
+        }
+        self.staff_token = create_jwt_for_user(self.staff_user)
+        self.student_token = create_jwt_for_user(self.student1)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + self.staff_token)
+        return super().setUp()
+
+    @ddt.data(
+        [{'email': 'new-student@example.com', 'course_id': 'course-v1:edX+DemoX+Demo_Course'}, status.HTTP_201_CREATED],
+        [{'course_id': 'course-v1:edX+DemoX+Demo_Course'}, status.HTTP_400_BAD_REQUEST],
+        [{'email': 'new-student@example.com'}, status.HTTP_400_BAD_REQUEST],
+    )
+    @ddt.unpack
+    def test_post_enrollment_allowed(self, data, expected_result):
+        """
+        Expected results:
+        - 201: If the request has email and course_id.
+        - 400: If the request has not.
+        """
+        response = self.client.post(self.url, data)
+        assert response.status_code == expected_result
+
+    def test_post_enrollment_allowed_without_staff(self):
+        """
+        Expected result:
+        - 403: Get when I am not staff.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + self.student_token)
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_get_enrollment_allowed_empty(self):
+        """
+        Expected result:
+        - Get the enrollment allowed from the request.user.
+        """
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_get_enrollment_allowed(self):
+        """
+        Expected result:
+        - Get the course enrollment allows.
+        """
+        response = self.client.post(path=self.url, data=self.data)
+        response = self.client.get(self.url, {"email": "new-student@example.com"})
+        self.assertContains(response, 'new-student@example.com', status_code=status.HTTP_200_OK)
+
+    def test_get_enrollment_allowed_without_staff(self):
+        """
+        Expected result:
+        - 403: Get when I am not staff.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + self.student_token)
+        response = self.client.get(self.url, {"email": "new-student@example.com"})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @ddt.data(
+        [{'email': 'new-student@example.com',
+          'course_id': 'course-v1:edX+DemoX+Demo_Course'},
+         status.HTTP_204_NO_CONTENT],
+        [{'email': 'other-student@example.com',
+          'course_id': 'course-v1:edX+DemoX+Demo_Course'},
+         status.HTTP_404_NOT_FOUND],
+        [{'course_id': 'course-v1:edX+DemoX+Demo_Course'},
+         status.HTTP_400_BAD_REQUEST],
+    )
+    @ddt.unpack
+    def test_delete_enrollment_allowed(self, delete_data, expected_result):
+        """
+        Expected results:
+        - 204: Enrollment allowed deleted.
+        - 404: Not found, the course enrollment allowed doesn't exists.
+        - 400: Bad request, missing data.
+        """
+        self.client.post(self.url, self.data)
+        response = self.client.delete(self.url, delete_data)
+        assert response.status_code == expected_result

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -228,6 +228,103 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert is_active
         assert course_mode == enrollment_mode
 
+    def test_enroll_with_email(self):
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user_email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+    def test_enroll_with_user_and_email(self):
+        # The user has priority over the email.
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username,
+                'user_email': 'another_email@example.com'
+            },
+            format='json'
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
+    @ddt.data(
+        # Default (no course modes in the database)
+        # Expect that users are automatically enrolled as the default
+        ([CourseMode.VERIFIED], CourseMode.VERIFIED, False),
+
+        # Audit / Verified
+        # We should always go to the "choose your course" page.
+        # We should also be enrolled as the default.
+        ([CourseMode.VERIFIED], CourseMode.VERIFIED, True),
+    )
+    @ddt.unpack
+    def test_force_enrollment(self, course_modes, enrollment_mode, force_enrollment):
+        # Create the course modes (if any) required for this test case
+        start_date = datetime.datetime(2021, 12, 1, 5, 0, 0, tzinfo=pytz.UTC)
+        end_date = datetime.datetime(2022, 12, 1, 5, 0, 0, tzinfo=pytz.UTC)
+        self.course = CourseFactory.create(
+            emit_signals=True,
+            start=start_date,
+            end=end_date,
+            enrollment_start=start_date,
+            enrollment_end=end_date,
+        )
+        for mode_slug in course_modes:
+            CourseModeFactory.create(
+                course_id=self.course.id,
+                mode_slug=mode_slug,
+                mode_display_name=mode_slug,
+            )
+
+        # If a user enroll himself in expired course
+        # whether force_enrollmet is True or False
+        self.assert_enrollment_status(
+            mode=CourseMode.VERIFIED,
+            expected_status=status.HTTP_403_FORBIDDEN,
+            force_enrollment=force_enrollment,
+        )
+
+        self.client.logout()
+        AdminFactory.create(username='global_staff', email='global_staff@example.com', password=self.PASSWORD)
+        self.client.login(username="global_staff", password=self.PASSWORD)
+
+        if force_enrollment:
+            # Create an enrollment
+            resp = self.assert_enrollment_status(
+                username=self.USERNAME,
+                mode=CourseMode.VERIFIED,
+                force_enrollment=force_enrollment,
+            )
+
+            # Verify that the response contains the correct course_name
+            data = json.loads(resp.content.decode('utf-8'))
+            assert self.course.display_name_with_default == data['course_details']['course_name']
+
+            # Verify that the enrollment was created correctly
+            assert CourseEnrollment.is_enrolled(self.user, self.course.id)
+            course_mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course.id)
+            assert is_active
+            assert course_mode == enrollment_mode
+        else:
+            # If a staff user enroll other user in expired course
+            # This will raise the CourseEnrollmentClosedError excecption
+            # and return status will be 400
+            self.assert_enrollment_status(
+                username=self.USERNAME,
+                mode=CourseMode.VERIFIED,
+                expected_status=status.HTTP_400_BAD_REQUEST,
+                force_enrollment=force_enrollment,
+            )
+
     def test_check_enrollment(self):
         CourseModeFactory.create(
             course_id=self.course.id,

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -228,7 +228,13 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert is_active
         assert course_mode == enrollment_mode
 
-    def test_enroll_with_email(self):
+    def test_enroll_with_email_staff(self):
+        # Create enrollments with email are allowed if you are staff.
+
+        self.client.logout()
+        AdminFactory.create(username='global_staff', email='global_staff@example.com', password=self.PASSWORD)
+        self.client.login(username="global_staff", password=self.PASSWORD)
+
         resp = self.client.post(
             reverse('courseenrollments'),
             {
@@ -241,8 +247,40 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         )
         assert resp.status_code == status.HTTP_200_OK
 
+    @patch('openedx.core.djangoapps.enrollments.views.EnrollmentListView.has_api_key_permissions')
+    def test_enroll_with_email_server(self, has_api_key_permissions_mock):
+        # Create enrollments with email are allowed if it is a server-to-server request.
+
+        has_api_key_permissions_mock.return_value = True
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'email': self.user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_200_OK
+
+    def test_enroll_with_email_without_staff(self):
+        # If you are not staff or server request you can't create enrollments with email.
+
+        resp = self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'email': self.other_user.email
+            },
+            format='json'
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
     def test_enroll_with_user_and_email(self):
-        # The user has priority over the email.
+        # Creating enrollments the user has priority over the email.
         resp = self.client.post(
             reverse('courseenrollments'),
             {
@@ -250,7 +288,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                     'course_id': str(self.course.id)
                 },
                 'user': self.user.username,
-                'email': 'another_email@example.com'
+                'email': self.other_user.email
             },
             format='json'
         )

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -406,6 +406,24 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
         assert data['is_active']
 
+    def test_get_enrollment_by_email(self):
+        # Create an enrollment
+        self.client.post(
+            reverse('courseenrollments'),
+            {
+                'course_details': {
+                    'course_id': str(self.course.id)
+                },
+                'user': self.user.username
+            },
+            format='json'
+        )
+        # Get the enrollment with an email
+        resp = self.client.get(
+            reverse('courseenrollment', kwargs={"username": str(self.user.email), "course_id": str(self.course.id)})
+        )
+        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
+
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
         self.client.logout()

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -406,24 +406,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         assert CourseMode.DEFAULT_MODE_SLUG == data['mode']
         assert data['is_active']
 
-    def test_get_enrollment_by_email(self):
-        # Create an enrollment
-        self.client.post(
-            reverse('courseenrollments'),
-            {
-                'course_details': {
-                    'course_id': str(self.course.id)
-                },
-                'user': self.user.username
-            },
-            format='json'
-        )
-        # Get the enrollment with an email
-        resp = self.client.get(
-            reverse('courseenrollment', kwargs={"username": str(self.user.email), "course_id": str(self.course.id)})
-        )
-        self.assertContains(resp, self.user.username, status_code=status.HTTP_200_OK)
-
     def test_user_not_authenticated(self):
         # Log out, so we're no longer authenticated
         self.client.logout()

--- a/openedx/core/djangoapps/enrollments/urls.py
+++ b/openedx/core/djangoapps/enrollments/urls.py
@@ -9,6 +9,7 @@ from django.urls import path, re_path
 
 from .views import (
     CourseEnrollmentsApiListView,
+    EnrollmentAllowedView,
     EnrollmentCourseDetailView,
     EnrollmentListView,
     EnrollmentUserRolesView,
@@ -29,4 +30,5 @@ urlpatterns = [
             EnrollmentCourseDetailView.as_view(), name='courseenrollmentdetails'),
     path('unenroll/', UnenrollmentView.as_view(), name='unenrollment'),
     path('roles/', EnrollmentUserRolesView.as_view(), name='roles'),
+    path('enrollment_allowed/', EnrollmentAllowedView.as_view(), name='courseenrollmentallowed'),
 ]

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -699,17 +699,17 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
 
         has_api_key_permissions = self.has_api_key_permissions(request)
 
-        # Check if the user or user_email was defined.
+        # Check if the user or email was defined.
         if not username:
-            user_email = request.data.get('user_email')
-            if user_email:
+            email = request.data.get('email')
+            if email:
                 try:
-                    username = User.objects.get(email=user_email).username
+                    username = User.objects.get(email=email).username
                 except ObjectDoesNotExist:
                     return Response(
                         status=status.HTTP_406_NOT_ACCEPTABLE,
                         data={
-                            'message': f'The user with the email address {user_email} does not exist.'
+                            'message': f'The user with the email address {email} does not exist.'
                         }
                     )
             else:

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -6,7 +6,6 @@ consist primarily of authentication, request validation, and serialization.
 
 
 import logging
-from re import match
 
 from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-import-order
     ObjectDoesNotExist,
@@ -202,17 +201,6 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
         """
         username = username or request.user.username
-        # If You send an email:
-        if bool(match(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', username)):
-            try:
-                username = User.objects.get(email=username).username
-            except ObjectDoesNotExist:
-                return Response(
-                    status=status.HTTP_406_NOT_ACCEPTABLE,
-                    data={
-                        'message': f'The user with the email address {username} does not exist.'
-                    }
-                )
 
         # TODO Implement proper permissions
         if request.user.username != username and not self.has_api_key_permissions(request) \

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -700,7 +700,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         has_api_key_permissions = self.has_api_key_permissions(request)
 
         # Check that the user specified is either the same user, or this is a server-to-server request.
-        if username != request.user.username and not has_api_key_permissions \
+        if username and username != request.user.username and not has_api_key_permissions \
                 and not GlobalStaff().has_user(request.user):
             # Return a 404 instead of a 403 (Unauthorized). If one user is looking up
             # other users, do not let them deduce the existence of an enrollment.
@@ -711,6 +711,9 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         if not username:
             email = request.data.get('email')
             if email:
+                # Only server-to-server or staff users can use the email for the request.
+                if not has_api_key_permissions and not GlobalStaff().has_user(request.user):
+                    return Response(status=status.HTTP_404_NOT_FOUND)
                 try:
                     username = User.objects.get(email=email).username
                 except ObjectDoesNotExist:

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -911,12 +911,17 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
 
             GET /api/enrollment/v1/enrollments?course_id={course_id}&username={username}
 
+            GET /api/enrollment/v1/enrollments?email={email},{email}
+
         **Query Parameters for GET**
 
             * course_id: Filters the result to course enrollments for the course corresponding to the
               given course ID. The value must be URL encoded. Optional.
 
             * username: List of comma-separated usernames. Filters the result to the course enrollments
+              of the given users. Optional.
+
+            * email: List of comma-separated emails. Filters the result to the course enrollments
               of the given users. Optional.
 
             * page_size: Number of results to return per page. Optional.
@@ -981,9 +986,12 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         queryset = CourseEnrollment.objects.all()
         course_id = form.cleaned_data.get('course_id')
         usernames = form.cleaned_data.get('username')
+        emails = form.cleaned_data.get('email')
 
         if course_id:
             queryset = queryset.filter(course_id=course_id)
         if usernames:
             queryset = queryset.filter(user__username__in=usernames)
+        if emails:
+            queryset = queryset.filter(user__email__in=emails)
         return queryset

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -11,6 +11,7 @@ from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-impo
     ObjectDoesNotExist,
     ValidationError
 )
+from django.db import IntegrityError    # lint-amnesty, pylint: disable=wrong-import-order
 from django.utils.decorators import method_decorator  # lint-amnesty, pylint: disable=wrong-import-order
 from edx_rest_framework_extensions.auth.jwt.authentication import \
     JwtAuthentication  # lint-amnesty, pylint: disable=wrong-import-order
@@ -26,7 +27,7 @@ from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.auth import user_has_role
-from common.djangoapps.student.models import CourseEnrollment, User
+from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed, User
 from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
 from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
@@ -41,7 +42,10 @@ from openedx.core.djangoapps.enrollments.errors import (
 )
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
-from openedx.core.djangoapps.enrollments.serializers import CourseEnrollmentsApiListSerializer
+from openedx.core.djangoapps.enrollments.serializers import (
+    CourseEnrollmentAllowedSerializer,
+    CourseEnrollmentsApiListSerializer
+)
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
@@ -999,3 +1003,165 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         if emails:
             queryset = queryset.filter(user__email__in=emails)
         return queryset
+
+
+class EnrollmentAllowedView(APIView):
+    """
+    A view that allows the retrieval and creation of enrollment allowed for a given user email and course id.
+    """
+    authentication_classes = (
+        JwtAuthentication,
+    )
+    permission_classes = (permissions.IsAdminUser,)
+    throttle_classes = (EnrollmentUserThrottle,)
+    serializer_class = CourseEnrollmentAllowedSerializer
+
+    def get(self, request):
+        """
+        Returns the enrollments allowed for a given user email.
+
+        **Example Requests**
+
+        GET /api/enrollment/v1/enrollment_allowed?email=user@example.com
+
+        **Parameters**
+
+        - `email` (optional, string, _query_params_) - defaults to the calling user if not provided.
+
+        **Responses**
+        - 200: Success.
+        - 403: Forbidden, you need to be staff.
+        """
+        user_email = request.query_params.get('email')
+        if not user_email:
+            user_email = request.user.email
+
+        enrollments_allowed = CourseEnrollmentAllowed.objects.filter(email=user_email) or []
+        serialized_enrollments_allowed = [
+            CourseEnrollmentAllowedSerializer(enrollment).data for enrollment in enrollments_allowed
+        ]
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=serialized_enrollments_allowed
+        )
+
+    def post(self, request):
+        """
+        Creates an enrollment allowed for a given user email and course id.
+
+        **Example Request**
+
+        POST /api/enrollment/v1/enrollment_allowed
+
+        Example request data:
+        ```
+        {
+            "email": "user@example.com",
+            "course_id": "course-v1:edX+DemoX+Demo_Course",
+            "auto_enroll": true
+        }
+        ```
+
+        **Parameters**
+
+        - `email` (**required**, string, _body_)
+
+        - `course_id` (**required**, string, _body_)
+
+        - `auto_enroll` (optional, bool: default=false, _body_)
+
+        **Responses**
+        - 200: Success, enrollment allowed found.
+        - 400: Bad request, missing data.
+        - 403: Forbidden, you need to be staff.
+        - 409: Conflict, enrollment allowed already exists.
+        """
+        is_bad_request_response, email, course_id = self.check_required_data(request)
+        auto_enroll = request.data.get('auto_enroll', False)
+        if is_bad_request_response:
+            return is_bad_request_response
+
+        try:
+            enrollment_allowed = CourseEnrollmentAllowed.objects.create(
+                email=email,
+                course_id=course_id,
+                auto_enroll=auto_enroll
+            )
+        except IntegrityError:
+            return Response(
+                status=status.HTTP_409_CONFLICT,
+                data={
+                    'message': f'An enrollment allowed with email {email} and course {course_id} already exists.'
+                }
+            )
+
+        serializer = CourseEnrollmentAllowedSerializer(enrollment_allowed)
+        return Response(
+            status=status.HTTP_201_CREATED,
+            data=serializer.data
+        )
+
+    def delete(self, request):
+        """
+        Deletes an enrollment allowed for a given user email and course id.
+
+        **Example Request**
+
+        DELETE /api/enrollment/v1/enrollment_allowed
+
+        Example request data:
+        ```
+        {
+            "email": "user@example.com",
+            "course_id": "course-v1:edX+DemoX+Demo_Course"
+        }
+        ```
+
+        **Parameters**
+
+        - `email` (**required**, string, _body_)
+
+        - `course_id` (**required**, string, _body_)
+
+        **Responses**
+        - 204: Enrollment allowed deleted.
+        - 400: Bad request, missing data.
+        - 403: Forbidden, you need to be staff.
+        - 404: Not found, the course enrollment allowed doesn't exists.
+        """
+        is_bad_request_response, email, course_id = self.check_required_data(request)
+        if is_bad_request_response:
+            return is_bad_request_response
+
+        try:
+            CourseEnrollmentAllowed.objects.get(
+                email=email,
+                course_id=course_id
+            ).delete()
+            return Response(
+                status=status.HTTP_204_NO_CONTENT,
+            )
+        except ObjectDoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={
+                    'message': f"An enrollment allowed with email {email} and course {course_id} doesn't exists."
+                }
+            )
+
+    def check_required_data(self, request):
+        """
+        Check if the request has email and course_id.
+        """
+        email = request.data.get('email')
+        course_id = request.data.get('course_id')
+        if not email or not course_id:
+            is_bad_request = Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "message": "Please provide a value for 'email' and 'course_id' in the request data."
+                })
+        else:
+            is_bad_request = None
+        return (is_bad_request, email, course_id)


### PR DESCRIPTION
## Description

This PR backports two key changes from `openedx/edx-platform` into the Nutmeg-based edunext Nimbus SaaS distribution. The goal is to allow our SaaS clients to use the new WordPress plugin [`openedx-commerce`](https://wordpress.org/plugins/openedx-commerce/), which only supports Quince or later.

Currently, some clients use the legacy plugin [`edunext-openedx-integrator`](https://wordpress.org/plugins/edunext-openedx-integrator/), which has not been maintained since 2020. This backport enables a migration path to the community-supported plugin without requiring a full upgrade to Quince.

Included changes:
- Backport of PR: [openedx/edx-platform#33006](https://github.com/openedx/edx-platform/pull/33006)
- Backport of PR: [openedx/edx-platform#33059](https://github.com/openedx/edx-platform/pull/33059)

## Supporting information

- This PR is part of the plan to officially deprecate support for the `edunext-openedx-integrator` plugin.
- Once deployed, clients will be notified via Lotus to switch to the `openedx-commerce` plugin.
- The old plugin will then be removed from the WordPress plugin repository.

## Testing instructions

**Warning: This PR has not yet been tested.**

Suggested testing steps:
1. Deploy this branch on a Nimbus instance running Nutmeg.
2. Have a platform with this PR.
3. Have a user for the test and a course with a mode specified in "mode" (You can add it in the admin in Course Modes).
4. Have an Authorization token (For example, a JWT token).
5. Verify no API conflicts or regressions.

### POST /api/enrollment/v1/enrollment
Header:

`Authorization: JWT YOUR_JWT_TOKEN`

Body:
```json
{
  "user_email": "user-1@example.com",
  "mode": "honor",
  "course_details": {
    "course_id": "course-v1:edX+DemoX+Demo_Course"
  }
}
```
Expected result: 200 and show the enrollment information.

### GET /api/enrollment/v1/enrollment/USER_EMAIL,COURSE_ID
Header:

`Authorization: JWT YOUR_JWT_TOKEN`

Expected result: 200 and show the enrollment information.


POST /api/enrollment/v1/enrollment_allowed
Example request data:

```json
{
        "email": "user@example.com",
        "course_id": "course-v1:edX+DemoX+Demo_Course",
        "auto_enroll": true
}
```

### GET /api/enrollment/v1/enrollment_allowed?email=[user@example.com](mailto:user@example.com)
Parameters

email (optional, string, query_params)

## Deadline

Preferably before coordinating the migration from Lotus and deprecating the old plugin.

## Other information

- This change does not impact clients already running Quince or newer.
- No additional configuration changes are required, assuming the new plugin is configured correctly.
- No known migrations, deprecations, or security issues are introduced in this PR.
